### PR TITLE
Tests: Allowed nested suites/modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,7 @@ grunt.initConfig({
 			src: [
 				"src/intro.js",
 				"src/core.js",
+				"src/suite.js",
 				"src/test.js",
 				"src/assert.js",
 				"src/equiv.js",
@@ -92,6 +93,8 @@ grunt.initConfig({
 		},
 		qunit: [
 			"test/index.html",
+			"test/suitesOrder.html",
+			"test/suites.html",
 			"test/autostart.html",
 			"test/startError.html",
 			"test/logs.html",
@@ -137,7 +140,7 @@ grunt.registerTask( "testswarm", function( commit, configFile, projectName, brow
 	}
 	timeout = timeout || 1000 * 60 * 15;
 
-	[ "index", "autostart", "startError", "setTimeout" ]
+	[ "index", "suitesOrder", "suites", "autostart", "startError", "setTimeout" ]
 		.forEach(function( suite ) {
 			runs[ suite ] = config.testUrl + commit + "/test/" + suite + ".html";
 		});

--- a/browserstack.json
+++ b/browserstack.json
@@ -4,6 +4,8 @@
 	"test_framework": "qunit",
 	"test_path": [
 		"test/index.html",
+		"test/suitesOrder.html",
+		"test/suites.html",
 		"test/startError.html",
 		"test/logs.html",
 		"test/setTimeout.html"

--- a/src/core.js
+++ b/src/core.js
@@ -286,11 +286,7 @@ config = {
 	// Set of all modules.
 	modules: {},
 
-	callbacks: {},
-
-	// When enabled, each test gets its own unique `this` context.
-	// When not enabled, all tests within a suite will share a `this` context.
-	atomicContext: true
+	callbacks: {}
 
 };
 

--- a/src/suite.js
+++ b/src/suite.js
@@ -1,0 +1,68 @@
+function Suite( name ) {
+	this.name = name;
+	this.parent = currentSuite;
+	this.beforeEach = [];
+	this.afterEach = [];
+}
+
+Suite.prototype.getSuiteHierarchy = function() {
+	var suite = this,
+		suites = [ suite ];
+	while ( ( suite = suite.parent ) ) {
+		suites.push( suite );
+	}
+	return suites;
+};
+
+Suite.prototype.getFullName = function() {
+	var i,
+		name = "",
+		allSuites = this.getSuiteHierarchy();
+
+	// Iterate the loop in reverse to start at the root suite
+	for ( i = allSuites.length; i--; ) {
+		if ( allSuites[ i ].name ) {
+			name += allSuites[ i ].name + " ";
+		}
+	}
+	return name.slice( 0, -1 );
+};
+
+function wrapSuiteHook( hookFn, suiteMeta ) {
+	return function( assert ) {
+		assert.suite = suiteMeta;
+		return hookFn.call( this, assert );
+	};
+}
+
+Suite.prototype.hooks = function( handler ) {
+	var i, j, callbackCount, callbacks, suiteMeta,
+		isAfterEach = handler === "afterEach",
+		callbackList = [],
+		allSuites = this.getSuiteHierarchy();
+
+	// Iterate the loop in reverse to start at the root suite
+	for ( i = allSuites.length; i--; ) {
+
+		// Provide consumers with useful temporal suite metadata along the way during execution
+		suiteMeta = {
+			name: allSuites[ i ].name,
+			fullName: allSuites[ i ].getFullName(),
+			depth: allSuites.length - i - 1
+		};
+
+		callbacks = allSuites[ i ][ handler ];
+
+		// If "afterEach", reverse a copy of the sub-array to ensure the suite-level order is as
+		// expected after the later `test.hooks( "afterEach" ).reverse()` call is finished
+		if ( isAfterEach ) {
+			callbacks = callbacks.slice().reverse();
+		}
+
+		for ( j = 0, callbackCount = callbacks.length; j < callbackCount; j++ ) {
+			callbackList.push( wrapSuiteHook( callbacks[ j ], suiteMeta ) );
+		}
+	}
+
+	return callbackList;
+};

--- a/test/suites.html
+++ b/test/suites.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>QUnit Suites Test Suite</title>
+	<link rel="stylesheet" href="../dist/qunit.css">
+	<script src="../dist/qunit.js"></script>
+	<script src="suites.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>

--- a/test/suites.js
+++ b/test/suites.js
@@ -1,0 +1,140 @@
+(function( suite, test, beforeEach, afterEach ) {
+	var testEnv, previousTestEnv,
+		expectedSuiteMeta = {
+			root: {
+				name: "",
+				fullName: "",
+				depth: 0
+			},
+			level1: {
+				name: "level1",
+				fullName: "level1",
+				depth: 1
+			},
+			level2: {
+				name: "level2",
+				fullName: "level1 level2",
+				depth: 2
+			}
+		};
+
+	beforeEach(function( assert ) {
+		previousTestEnv = testEnv;
+		testEnv = this;
+		assert.deepEqual(
+			assert.suite,
+			expectedSuiteMeta.root,
+			"During the root suite's beforeEach, assert.suite represents the root suite"
+		);
+		assert.notEqual( testEnv, previousTestEnv, "Using a different testEnvironment from the last test (if any)" );
+	});
+
+	test( "test1", function( assert ) {
+		assert.expect( 6 );
+		assert.deepEqual(
+			assert.suite,
+			expectedSuiteMeta.root,
+			"During the root suite's pre-nesting test callback, assert.suite represents the root suite"
+		);
+		assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+	});
+
+	suite( "level1", function() {
+		beforeEach(function( assert ) {
+			assert.deepEqual(
+				assert.suite,
+				expectedSuiteMeta.level1,
+				"During the level1 suite's beforeEach, assert.suite represents the level1 suite"
+			);
+			assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+	});
+
+		test( "test2", function( assert ) {
+			assert.expect( 10 );
+			assert.deepEqual(
+				assert.suite,
+				expectedSuiteMeta.level1,
+				"During the level1 suite's pre-nesting test callback, assert.suite represents the level1 suite"
+			);
+			assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+		});
+
+		suite( "level2", function() {
+			beforeEach(function( assert ) {
+				assert.deepEqual(
+					assert.suite,
+					expectedSuiteMeta.level2,
+					"During the level2 suite's beforeEach, assert.suite represents the level2 suite"
+				);
+				assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+			});
+
+			test( "test3", function( assert ) {
+				assert.expect( 14 );
+				assert.deepEqual(
+					assert.suite,
+					expectedSuiteMeta.level2,
+					"During the level2 suite's first test callback, assert.suite represents the level2 suite"
+				);
+				assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+			});
+			test( "test4", function( assert ) {
+				assert.expect( 14 );
+				assert.deepEqual(
+					assert.suite,
+					expectedSuiteMeta.level2,
+					"During the level2 suite's last test callback, assert.suite represents the level2 suite"
+				);
+				assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+			});
+
+			afterEach(function( assert ) {
+				assert.deepEqual(
+					assert.suite,
+					expectedSuiteMeta.level2,
+					"During the level2 suite's afterEach, assert.suite represents the level2 suite"
+				);
+				assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+			});
+		});
+
+		test( "test5", function( assert ) {
+			assert.expect( 10 );
+			assert.deepEqual(
+				assert.suite,
+				expectedSuiteMeta.level1,
+				"During the level1 suite's post-nesting test callback, assert.suite represents the level1 suite"
+			);
+			assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+		});
+
+		afterEach(function( assert ) {
+			assert.deepEqual(
+				assert.suite,
+				expectedSuiteMeta.level1,
+				"During the level1 suite's afterEach, assert.suite represents the level1 suite"
+			);
+			assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+		});
+	});
+
+	test( "test6", function( assert ) {
+		assert.expect( 6 );
+		assert.deepEqual(
+			assert.suite,
+			expectedSuiteMeta.root,
+			"During the root suite's post-nesting test callback, assert.suite represents the root suite"
+		);
+		assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+	});
+
+	afterEach(function( assert ) {
+		assert.deepEqual(
+			assert.suite,
+			expectedSuiteMeta.root,
+			"During the root suite's afterEach, assert.suite represents the root suite"
+		);
+		assert.strictEqual( this, testEnv, "Still using the same testEnvironment" );
+	});
+
+})( QUnit.suite, QUnit.test, QUnit.beforeEach, QUnit.afterEach );

--- a/test/suitesOrder.html
+++ b/test/suitesOrder.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>QUnit Suites Order Test Suite</title>
+	<link rel="stylesheet" href="../dist/qunit.css">
+	<script src="../dist/qunit.js"></script>
+	<script>
+		// Do NOT allow the tests to be reordered
+		QUnit.config.reorder = false;
+	</script>
+	<script src="suitesOrder.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>

--- a/test/suitesOrder.js
+++ b/test/suitesOrder.js
@@ -1,0 +1,157 @@
+var execHistoryCopy,
+	execHistory = [];
+
+(function( suite, test, beforeEach, afterEach ) {
+
+	beforeEach(function( assert ) {
+		execHistory.push( assert.suite.fullName + ".beforeEach1" );
+	});
+	beforeEach(function( assert ) {
+		execHistory.push( assert.suite.fullName + ".beforeEach2" );
+	});
+
+	test( "test1", function( assert ) {
+		assert.expect( 0 );
+		execHistory.push( assert.suite.fullName + " -> test1.callback" );
+	});
+
+	suite( "level1", function() {
+		beforeEach(function( assert ) {
+			execHistory.push( assert.suite.fullName + ".beforeEach1" );
+		});
+		beforeEach(function( assert ) {
+			execHistory.push( assert.suite.fullName + ".beforeEach2" );
+		});
+
+		test( "test2", function( assert ) {
+			assert.expect( 0 );
+			execHistory.push( assert.suite.fullName + " -> test2.callback" );
+		});
+
+		suite( "level2", function() {
+			beforeEach(function( assert ) {
+				execHistory.push( assert.suite.fullName + ".beforeEach1" );
+			});
+			beforeEach(function( assert ) {
+				execHistory.push( assert.suite.fullName + ".beforeEach2" );
+			});
+
+			test( "test3", function( assert ) {
+				assert.expect( 0 );
+				execHistory.push( assert.suite.fullName + " -> test3.callback" );
+			});
+			test( "test4", function( assert ) {
+				assert.expect( 0 );
+				execHistory.push( assert.suite.fullName + " -> test4.callback" );
+			});
+
+			afterEach(function( assert ) {
+				execHistory.push( assert.suite.fullName + ".afterEach1" );
+			});
+			afterEach(function( assert ) {
+				execHistory.push( assert.suite.fullName + ".afterEach2" );
+			});
+		});
+
+		test( "test5", function( assert ) {
+			assert.expect( 0 );
+			execHistory.push( assert.suite.fullName + " -> test5.callback" );
+		});
+
+		afterEach(function( assert ) {
+			execHistory.push( assert.suite.fullName + ".afterEach1" );
+		});
+		afterEach(function( assert ) {
+			execHistory.push( assert.suite.fullName + ".afterEach2" );
+		});
+	});
+
+	test( "test6", function( assert ) {
+		assert.expect( 0 );
+		execHistory.push( assert.suite.fullName + " -> test6.callback" );
+	});
+
+	afterEach(function( assert ) {
+		execHistory.push( assert.suite.fullName + ".afterEach1" );
+	});
+	afterEach(function( assert ) {
+		execHistory.push( assert.suite.fullName + ".afterEach2" );
+	});
+
+})( QUnit.suite, QUnit.test, QUnit.beforeEach, QUnit.afterEach );
+
+QUnit.module( "suites", {
+	beforeEach: function() {
+		if ( !execHistoryCopy ) {
+
+			// Remove two global/root suite's `beforeEach` entries triggered by this `QUnit.module` call
+			execHistoryCopy = execHistory.slice( 0, -2 );
+			execHistory.length = 0;
+		}
+	}
+});
+
+QUnit.test( "hierarchical suite contexts executed in expected order", function( assert ) {
+	assert.expect( 1 );
+	assert.deepEqual(
+		execHistoryCopy,
+		[
+			// Entries without a suite name prefix are defined at the level of the root suite
+			".beforeEach1",
+			".beforeEach2",
+			" -> test1.callback",
+			".afterEach1",
+			".afterEach2",
+			".beforeEach1",
+			".beforeEach2",
+			"level1.beforeEach1",
+			"level1.beforeEach2",
+			"level1 -> test2.callback",
+			"level1.afterEach1",
+			"level1.afterEach2",
+			".afterEach1",
+			".afterEach2",
+			".beforeEach1",
+			".beforeEach2",
+			"level1.beforeEach1",
+			"level1.beforeEach2",
+			"level1 level2.beforeEach1",
+			"level1 level2.beforeEach2",
+			"level1 level2 -> test3.callback",
+			"level1 level2.afterEach1",
+			"level1 level2.afterEach2",
+			"level1.afterEach1",
+			"level1.afterEach2",
+			".afterEach1",
+			".afterEach2",
+			".beforeEach1",
+			".beforeEach2",
+			"level1.beforeEach1",
+			"level1.beforeEach2",
+			"level1 level2.beforeEach1",
+			"level1 level2.beforeEach2",
+			"level1 level2 -> test4.callback",
+			"level1 level2.afterEach1",
+			"level1 level2.afterEach2",
+			"level1.afterEach1",
+			"level1.afterEach2",
+			".afterEach1",
+			".afterEach2",
+			".beforeEach1",
+			".beforeEach2",
+			"level1.beforeEach1",
+			"level1.beforeEach2",
+			"level1 -> test5.callback",
+			"level1.afterEach1",
+			"level1.afterEach2",
+			".afterEach1",
+			".afterEach2",
+			".beforeEach1",
+			".beforeEach2",
+			" -> test6.callback",
+			".afterEach1",
+			".afterEach2"
+		],
+		"Should verify execution order"
+	);
+});


### PR DESCRIPTION
Fixes #543
Closes #670

Debatably a work-in-progress... but... it works pretty well so far! :+1:

For the sake of comparison (and so I didn't go crazy), I chose to implement this functionality in a separate API method, `QUnit.suite`, rather than trying to make `QUnit.module` work in 2 very different ways.  They can conceivably be combined, though.

Another note of interest in how I chose to make suites work differently than modules: every test inside of a suite gets its own atomic context object that can be modified along the way by every level's `beforeEach`/`afterEach` calls. Conversely, using modules, every test within that module shares a shallow copy of the same context object.