### PR TITLE
Build: Support Node.js export parity with CommonJS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -215,6 +215,7 @@ grunt.registerTask( "test-on-node", function() {
 	require( "./test/modules" );
 	require( "./test/deepEqual" );
 	require( "./test/globals" );
+	require( "./test/globals-node" );
 
 	QUnit.load();
 });

--- a/src/export.js
+++ b/src/export.js
@@ -49,11 +49,14 @@ if ( typeof window !== "undefined" ) {
 }
 
 // For nodejs
-if ( typeof module !== "undefined" && module.exports ) {
+if ( typeof module !== "undefined" && module && module.exports ) {
 	module.exports = QUnit;
+
+	// For consistency with CommonJS environments' exports
+	module.exports.QUnit = QUnit;
 }
 
 // For CommonJS with exports, but without module.exports, like Rhino
-if ( typeof exports !== "undefined" ) {
+if ( typeof exports !== "undefined" && exports ) {
 	exports.QUnit = QUnit;
 }

--- a/test/globals-node.js
+++ b/test/globals-node.js
@@ -1,0 +1,20 @@
+/*jshint node:true */
+(function() {
+
+QUnit.module( "globals for Node.js only" );
+
+QUnit.test( "QUnit exports", function( assert ) {
+	var qunit = require( "../dist/qunit" );
+
+	assert.ok( qunit, "Required module QUnit truthy" );
+	assert.strictEqual( qunit, QUnit, "Required module QUnit matches global QUnit" );
+
+	assert.ok( qunit.hasOwnProperty( "QUnit" ), "Required module QUnit has property QUnit" );
+	assert.strictEqual(
+		qunit.QUnit,
+		qunit,
+		"Required module QUnit's property QUnit is self-referencing"
+	);
+});
+
+})();

--- a/test/globals.js
+++ b/test/globals.js
@@ -27,10 +27,6 @@ function checkExported( assert, methods, isAssertion ) {
 	}
 }
 
-QUnit.test( "QUnit object", function( assert ) {
-	assert.ok( QUnit instanceof QUnit.constructor, "Global QUnit built from it's own constructor" );
-});
-
 QUnit.test( "QUnit exported methods", function( assert ) {
 	var globals = [
 			"test", "asyncTest", "module",


### PR DESCRIPTION
Ref #521
More info: https://github.com/jquery/qunit/issues/521#issuecomment-65656852

Basically, we want to ensure that `require('qunitjs').QUnit` works in all CommonJS environments, even if it is achieved by `QUnit.QUnit = QUnit`. Node.js was the only outlier at this point.

Also added and updated a few related tests.