### PR TITLE
Build: Enable PR testing with browserstack-runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ node_js:
   - "0.10"
 before_install:
   - npm install -g grunt-cli
+  - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19VU0VSTkFNRT1icm93c2Vyc3RhY2txdW5pMQo=`
+  - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19LRVk9SllzeHJrVWk5aGJGVndkdW44ZUsK=`
 script:
   - npm run-script ci

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
+    "browserstack-runner": "0.2.2",
     "commitplease": "2.0.0",
     "grunt": "0.4.2",
     "grunt-contrib-concat": "0.3.0",
@@ -47,7 +48,7 @@
     "testswarm": "1.1.0"
   },
   "scripts": {
-    "ci": "grunt && grunt coveralls",
+    "ci": "grunt && grunt coveralls && browserstack-runner",
     "test": "grunt",
     "prepublish": "grunt build"
   },


### PR DESCRIPTION
This runs our unit tests on all supported browsers for all commits, including pull requests, using the existing `browserstack-runner` configuration. A [sample run](https://travis-ci.org/jzaefferer/qunit/builds/45673762) took 2 1/2 minutes to test on 14 browsers.

This works, but I expect that we'll get the occasional failure, likely with one or more workers timing out, [like this](https://travis-ci.org/jzaefferer/qunit/builds/45670237). I think thats an acceptable tradeoff. We'll continue working with BrowserStack to make testing more reliable.

As for the obscured credentials: Those are easy enough to decode, the point is to avoid them being searchable, that is a search for "browserstack" on GitHub won't immediately show these credentials. This is a temporary solution until Travis CI [implements a proper one](https://github.com/travis-ci/travis-ci/issues/1946).

Once this lands I'm going to apply this for Globalize as well ([configuration is already in place](https://github.com/jquery/globalize/pull/367)). From there we can see how to move on, to eventually shut down TestSwarm and maybe replace Sizzle's use of Karma.