### PR TITLE
Fix potential XSS attack

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -444,7 +444,7 @@ function storeFixture() {
 function appendUserAgent() {
 	var userAgent = id( "qunit-userAgent" );
 	if ( userAgent ) {
-		userAgent.innerHTML = navigator.userAgent;
+		userAgent.innerText = navigator.userAgent;
 	}
 }
 


### PR DESCRIPTION
A malicious user with control of the user agent string can create a XSS attack because of this. Because many libs include the test page with bower is often accessible this can end up being a risk. See https://twitter.com/_ham1d/status/432903086575980544