### PR TITLE
Build: Ignore BrowserStack generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 build/report
 browserstack-run.pid
+BrowserStackLocal


### PR DESCRIPTION
BrowserStack-runner is generating this binary file to the project's root