### PR TITLE
HTML Reporter: handle case where unit root element is not present

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,7 +96,8 @@ grunt.initConfig({
 			"test/autostart.html",
 			"test/startError.html",
 			"test/logs.html",
-			"test/setTimeout.html"
+			"test/setTimeout.html",
+			"test/reporter-html-no-qunit-element.html"
 		]
 	},
 	coveralls: {

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -384,7 +384,7 @@ function toolbarModuleFilter() {
 		moduleFilter = document.createElement( "span" ),
 		moduleFilterHtml = toolbarModuleFilterHtml();
 
-	if ( !moduleFilterHtml ) {
+	if ( !toolbar || !moduleFilterHtml ) {
 		return false;
 	}
 

--- a/test/reporter-html-no-qunit-element.html
+++ b/test/reporter-html-no-qunit-element.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>QUnit Main Test Suite</title>
+	<link rel="stylesheet" href="../dist/qunit.css">
+	<script src="../dist/qunit.js"></script>
+	<script src="reporter-html-no-qunit-element.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/reporter-html-no-qunit-element.js
+++ b/test/reporter-html-no-qunit-element.js
@@ -1,0 +1,10 @@
+(function() {
+
+QUnit.module( "reporter-html-no-qunit-element");
+
+QUnit.test( "reporter/html when no qunit element present", function( assert ) {
+	assert.expect( 1 );
+    assert.ok(true);
+});
+
+})();


### PR DESCRIPTION
I suddenly started getting this error when using QUnit with Karma:

```
PhantomJS 1.9.8 (Mac OS X) ERROR
  TypeError: 'null' is not an object (evaluating 'toolbar.appendChild')
  at /Users/jonbretman/git/lyst/node_modules/qunitjs/qunit/qunit.js:2534
```

After some digging found that this bug was introduced with [this commit](https://github.com/jquery/qunit/commit/3fa5f6a4e4ead6b588376f6621fc3c4baab57444#diff-5b7e94e2a10b848c4ae4b539388f86ae). Before `appendToolbar` would check that the toolbar (`#qunit-testrunner-toolbar`) existed before trying to append to it, but the above mentioned commit changed it so that `toolbarModuleFilter` did the appending to the toolbar directly, but without checking first that it exists.