### PR TITLE
Retain failed test numbers when using hidepassed by moving passed tests off-screen instead of hiding them

### DIFF
--- a/src/qunit.css
+++ b/src/qunit.css
@@ -116,7 +116,11 @@
 
 #qunit-tests.hidepass li.running,
 #qunit-tests.hidepass li.pass {
-	display: none;
+	position: absolute;
+	left: -100px;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
 }
 
 #qunit-tests li strong {

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -116,11 +116,12 @@
 
 #qunit-tests.hidepass li.running,
 #qunit-tests.hidepass li.pass {
-	position: absolute;
-	left: -100px;
-	width: 1px;
-	height: 1px;
-	overflow: hidden;
+	visibility: hidden;
+	width:   0px;
+	height:  0px;
+	padding: 0;
+	border:  0;
+	margin:  0;
 }
 
 #qunit-tests li strong {


### PR DESCRIPTION
When using the `hidepassed` option, since an `<ol>` is providing test numbers, the original numbers for any failed tests which follow passed tests are lost when `<li>`s for passed tests are hidden.

Moving `<li>`s for passed tests off the screen instead retains the failed test numbers.

Before:
![qunit-before](https://cloud.githubusercontent.com/assets/226692/5826123/482c644e-a0e8-11e4-8c60-505f7230dd4f.png)

After:
![qunit-after](https://cloud.githubusercontent.com/assets/226692/5826124/488ace8a-a0e8-11e4-9bd4-561836638ab6.png)
