### PR TITLE
Update ignoreGlobalErrors only if this.test is defined

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -119,15 +119,17 @@ QUnit.assert = Assert.prototype = {
 			expected = null;
 		}
 
-		if (this.test)
+		if (this.test) {
 			this.test.ignoreGlobalErrors = true;
+		}
 		try {
 			block.call( this.test.testEnvironment );
 		} catch (e) {
 			actual = e;
 		}
-		if (this.test)
+		if (this.test) {
 			this.test.ignoreGlobalErrors = false;
+		}
 
 		if ( actual ) {
 			expectedType = QUnit.objectType( expected );

--- a/src/assert.js
+++ b/src/assert.js
@@ -119,13 +119,15 @@ QUnit.assert = Assert.prototype = {
 			expected = null;
 		}
 
-		this.test.ignoreGlobalErrors = true;
+		if (this.test)
+			this.test.ignoreGlobalErrors = true;
 		try {
 			block.call( this.test.testEnvironment );
 		} catch (e) {
 			actual = e;
 		}
-		this.test.ignoreGlobalErrors = false;
+		if (this.test)
+			this.test.ignoreGlobalErrors = false;
 
 		if ( actual ) {
 			expectedType = QUnit.objectType( expected );


### PR DESCRIPTION
I have some tests failing around these lines since 1.17.1 (before I was in 1.14.0).

Changing these lines made my tests work again.