### PR TITLE
Fix #749 - Filter does not work correctly with upper case letter in test name

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -345,7 +345,7 @@ Test.prototype = {
 
 	valid: function() {
 		var include,
-			filter = config.filter,
+			filter = config.filter && config.filter.toLowerCase(),
 			module = QUnit.urlParams.module && QUnit.urlParams.module.toLowerCase(),
 			fullName = ( this.module.name + ": " + this.testName ).toLowerCase();
 
@@ -368,7 +368,7 @@ Test.prototype = {
 
 		include = filter.charAt( 0 ) !== "!";
 		if ( !include ) {
-			filter = filter.toLowerCase().slice( 1 );
+			filter = filter.slice( 1 );
 		}
 
 		// If the filter matches, we need to honour include


### PR DESCRIPTION
As of 1.17.1, filters do not work when the module name contains upper case letters (#749) which was introduced by 1d44eb38052d25d97a631b9711e481303fc472b6.

This fixes it by changing `valid()` to lowercase the filter before using it further.