### PR TITLE
HTML Reporter: Fix test filter without any module

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -289,12 +289,16 @@ function setUrl( params ) {
 }
 
 function applyUrlParams() {
-	var selectBox = id( "qunit-modulefilter" ),
-		selection = decodeURIComponent( selectBox.options[ selectBox.selectedIndex ].value ),
+	var selectedModule,
+		modulesList = id( "qunit-modulefilter" ),
 		filter = id( "qunit-filter-input" ).value;
 
+	selectedModule = modulesList ?
+		decodeURIComponent( modulesList.options[ modulesList.selectedIndex ].value ) :
+		undefined;
+
 	window.location = setUrl({
-		module: ( selection === "" ) ? undefined : selection,
+		module: ( selectedModule === "" ) ? undefined : selectedModule,
 		filter: ( filter === "" ) ? undefined : filter,
 
 		// Remove testId filter


### PR DESCRIPTION
Without any module at the test suite, the Reporter doesn't create
the select tag to filter the modules. The test filter was trying
to get the selected value to set the filter in order to keep it
at the url parameters.

Closes #748