### PR TITLE
Assert: Fix missing test on exported throws

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -117,7 +117,8 @@ QUnit.assert = Assert.prototype = {
 	"throws": function( block, expected, message ) {
 		var actual, expectedType,
 			expectedOutput = expected,
-			ok = false;
+			ok = false,
+			currentTest = ( this instanceof Assert && this.test ) || QUnit.config.current;
 
 		// 'expected' is optional unless doing string comparison
 		if ( message == null && typeof expected === "string" ) {
@@ -125,13 +126,13 @@ QUnit.assert = Assert.prototype = {
 			expected = null;
 		}
 
-		this.test.ignoreGlobalErrors = true;
+		currentTest.ignoreGlobalErrors = true;
 		try {
-			block.call( this.test.testEnvironment );
+			block.call( currentTest.testEnvironment );
 		} catch (e) {
 			actual = e;
 		}
-		this.test.ignoreGlobalErrors = false;
+		currentTest.ignoreGlobalErrors = false;
 
 		if ( actual ) {
 			expectedType = QUnit.objectType( expected );
@@ -165,9 +166,9 @@ QUnit.assert = Assert.prototype = {
 				ok = true;
 			}
 
-			this.push( ok, actual, expectedOutput, message );
+			currentTest.assert.push( ok, actual, expectedOutput, message );
 		} else {
-			this.test.pushFailure( message, null, "No exception was thrown." );
+			currentTest.pushFailure( message, null, "No exception was thrown." );
 		}
 	}
 };

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,4 +1,4 @@
-/*global ok: false, equal: false */
+/*global ok: false, equal: false, throws: false */
 (function( window ) {
 
 QUnit.module( "globals" );
@@ -41,16 +41,25 @@ QUnit.test( "QUnit exported methods", function( assert ) {
 
 // Test deprecated exported Assert methods
 QUnit.test( "Exported assertions", function() {
-	QUnit.expect( 6 );
+	QUnit.expect( 9 );
 
 	QUnit.ok( true );
 	QUnit.equal( 2, 2 );
+	QUnit.throws(function() {
+		throw "error";
+	});
 
 	ok( true );
 	equal( 2, 2 );
+	throws(function() {
+		throw "error";
+	});
 
 	QUnit.assert.ok( true );
 	QUnit.assert.equal( 2, 2 );
+	QUnit.assert.throws(function() {
+		throw "error";
+	});
 });
 
 // Get a reference to the global object, like window in browsers


### PR DESCRIPTION
Fixes regression found at #752 and add tests for exported throws assertions.
