### PR TITLE
Dump: Fix .name/.message property doublettes in parsers.object

### DIFF
--- a/src/dump.js
+++ b/src/dump.js
@@ -174,7 +174,7 @@ QUnit.dump = (function() {
 					nonEnumerableProperties = [ "message", "name" ];
 					for ( i in nonEnumerableProperties ) {
 						key = nonEnumerableProperties[ i ];
-						if ( key in map && !( key in keys ) ) {
+						if ( key in map && inArray( key, keys ) < 0 ) {
 							keys.push( key );
 						}
 					}


### PR DESCRIPTION
Now using inArray() the correct way.

Fixes #750