### PR TITLE
HTML Reporter: Change display text for bad tests

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -612,12 +612,10 @@ QUnit.testStart(function( details ) {
 
 	running = id( "qunit-testresult" );
 	if ( running ) {
-		if ( details.bad === true ) {
-			running.innerHTML = "Rerunning failed: <br />" +
+		running.innerHTML = details.wasBad ?
+			"Rerunning previously failed test: <br />" :
+			"Running: <br />" +
 				getNameHtml( details.name, details.module );
-		} else {
-			running.innerHTML = "Running: <br />" + getNameHtml( details.name, details.module );
-		}
 	}
 
 });

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -612,7 +612,12 @@ QUnit.testStart(function( details ) {
 
 	running = id( "qunit-testresult" );
 	if ( running ) {
-		running.innerHTML = "Running: <br />" + getNameHtml( details.name, details.module );
+		if ( details.bad === true ) {
+			running.innerHTML = "Rerunning failed: <br />" +
+				getNameHtml( details.name, details.module );
+		} else {
+			running.innerHTML = "Running: <br />" + getNameHtml( details.name, details.module );
+		}
 	}
 
 });

--- a/src/test.js
+++ b/src/test.js
@@ -80,7 +80,7 @@ Test.prototype = {
 			name: this.testName,
 			module: this.module.name,
 			testId: this.testId,
-			bad: this.wasBad
+			wasBad: this.wasBad
 		});
 
 		if ( !config.pollution ) {

--- a/src/test.js
+++ b/src/test.js
@@ -9,6 +9,7 @@ function Test( settings ) {
 	this.usedAsync = false;
 	this.module = config.currentModule;
 	this.stack = sourceFromStacktrace( 3 );
+	this.wasBad = false;
 
 	// Register unique strings
 	for ( i = 0, l = this.module.tests; i < l.length; i++ ) {
@@ -78,7 +79,8 @@ Test.prototype = {
 		runLoggingCallbacks( "testStart", {
 			name: this.testName,
 			module: this.module.name,
-			testId: this.testId
+			testId: this.testId,
+			bad: this.wasBad
 		});
 
 		if ( !config.pollution ) {
@@ -253,6 +255,7 @@ Test.prototype = {
 				+sessionStorage.getItem( "qunit-test-" + this.module.name + "-" + this.testName );
 
 		if ( bad ) {
+			test.wasBad = true;
 			run();
 		} else {
 			synchronize( run, true );

--- a/test/logs.js
+++ b/test/logs.js
@@ -145,7 +145,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 
 	assert.strictEqual( testDoneContext, undefined, "testDone context" );
 	assert.deepEqual( testContext, {
-		bad: false,
+		wasBad: false,
 		module: module1Context.name,
 		name: module1Test1.name,
 		testId: module1Test1.testId
@@ -191,7 +191,7 @@ QUnit.test( module1Test2.name, function( assert ) {
 	}, "testDone context" );
 	assert.deepEqual( testContext, {
 		module: module1Context.name,
-		bad: false,
+		wasBad: false,
 		name: module1Test2.name,
 		testId: module1Test2.testId
 	}, "test context" );
@@ -213,7 +213,7 @@ QUnit.test( module2Test1.name, function( assert ) {
 
 	assert.deepEqual( testContext, {
 		module: module2Context.name,
-		bad: false,
+		wasBad: false,
 		name: module2Test1.name,
 		testId: module2Test1.testId
 	}, "test context" );
@@ -247,7 +247,7 @@ QUnit.test( module2Test2.name, function( assert ) {
 
 	assert.deepEqual( testContext, {
 		module: module2Context.name,
-		bad: false,
+		wasBad: false,
 		name: module2Test2.name,
 		testId: module2Test2.testId
 	}, "test context" );

--- a/test/logs.js
+++ b/test/logs.js
@@ -145,6 +145,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 
 	assert.strictEqual( testDoneContext, undefined, "testDone context" );
 	assert.deepEqual( testContext, {
+		bad: false,
 		module: module1Context.name,
 		name: module1Test1.name,
 		testId: module1Test1.testId
@@ -190,6 +191,7 @@ QUnit.test( module1Test2.name, function( assert ) {
 	}, "testDone context" );
 	assert.deepEqual( testContext, {
 		module: module1Context.name,
+		bad: false,
 		name: module1Test2.name,
 		testId: module1Test2.testId
 	}, "test context" );
@@ -211,6 +213,7 @@ QUnit.test( module2Test1.name, function( assert ) {
 
 	assert.deepEqual( testContext, {
 		module: module2Context.name,
+		bad: false,
 		name: module2Test1.name,
 		testId: module2Test1.testId
 	}, "test context" );
@@ -244,6 +247,7 @@ QUnit.test( module2Test2.name, function( assert ) {
 
 	assert.deepEqual( testContext, {
 		module: module2Context.name,
+		bad: false,
 		name: module2Test2.name,
 		testId: module2Test2.testId
 	}, "test context" );


### PR DESCRIPTION
When displaying text for running tests, if
QUnit.config.reorder is enabled then previously
failed tests will run first. However in summary
there is no indication for the same. This commit
changes the message text in HTML reporter.

Fixes #693