### PR TITLE
Assert: changed object equivalence test to make it faster

### DIFF
--- a/src/equiv.js
+++ b/src/equiv.js
@@ -28,6 +28,24 @@ QUnit.equiv = (function() {
 			/* jshint camelcase: false, proto: true */
 			return obj.__proto__;
 		},
+
+		objectsHaveSameKeys = function( b, a ) {
+			var i;
+			for ( i in b ) {
+				if ( !( i in a ) ) {
+					return false;
+				}
+			}
+
+			for ( i in a ) {
+				if ( !(i in b ) ) {
+					return false;
+				}
+			}
+
+			return true;
+		},
+
 		callbacks = (function() {
 
 			// for string, boolean, number and null
@@ -186,7 +204,7 @@ QUnit.equiv = (function() {
 					}
 
 					// Ensures b doesn't have any property that a doesn't
-					return eq && aProperties.length === bProperties.length;
+					return eq && objectsHaveSameKeys( a, b );
 				}
 			};
 		}());

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -185,8 +185,8 @@ QUnit.equiv = (function() {
 						bProperties.push( i ); // collect b's properties
 					}
 
-					// Ensures identical properties name
-					return eq && innerEquiv( aProperties.sort(), bProperties.sort() );
+					// Ensures b doesn't have any property that a doesn't
+					return eq && aProperties.length === bProperties.length;
 				}
 			};
 		}());


### PR DESCRIPTION
It's certainly a minor change, but it helped my computer run the tests provided with qunit 0.3 seconds faster on average.

This "trick" is widely used to prove that two sets are equal, that is, if one set A is contained in B and both have the same size, then they must be equal. It's quite intuitive I guess. The advantage of using this approach instead of the old one is that we are able to change an O(n * log n) operation with a O(1) operation, which would be kind of a big deal if QUnit.equiv was used to compare large objects.