### PR TITLE
Core: Simplify stack trace methods

### DIFF
--- a/browserstack.json
+++ b/browserstack.json
@@ -10,18 +10,33 @@
 	],
 	"browsers": [
 		"chrome_previous",
-		"chrome_latest",
+		"chrome_current",
 		"firefox_previous",
-		"firefox_latest",
+		"firefox_current",
+		"opera_12_1",
 		"opera_previous",
-		"opera_latest",
+		"opera_current",
+		"safari_5_1",
+		"safari_6",
 		"safari_previous",
-		"safari_latest",
+		"safari_current",
 		"ie_6",
 		"ie_7",
 		"ie_8",
 		"ie_9",
 		"ie_10",
-		"ie_11"
+		"ie_11",
+		{
+			"os": "iOS",
+			"os_version": "6.0"
+		},
+		{
+			"os": "iOS",
+			"os_version": "7.0"
+		},
+		{
+			"os": "iOS",
+			"os_version": "8.0"
+		}
 	]
 }

--- a/src/core.js
+++ b/src/core.js
@@ -483,20 +483,14 @@ function done() {
 	});
 }
 
-// Doesn't support IE6 to IE9
+// Doesn't support IE6 to IE9, it will return undefined on these browsers
 // See also https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error/Stack
 function extractStacktrace( e, offset ) {
 	offset = offset === undefined ? 4 : offset;
 
 	var stack, include, i;
 
-	if ( e.stacktrace ) {
-
-		// Opera 12.x
-		return e.stacktrace.split( "\n" )[ offset + 3 ];
-	} else if ( e.stack ) {
-
-		// Firefox, Chrome, Safari 6+, IE10+, PhantomJS and Node
+	if ( e.stack ) {
 		stack = e.stack.split( "\n" );
 		if ( /^error$/i.test( stack[ 0 ] ) ) {
 			stack.shift();
@@ -514,9 +508,10 @@ function extractStacktrace( e, offset ) {
 			}
 		}
 		return stack[ offset ];
+
+	// Support: Safari <=6 only
 	} else if ( e.sourceURL ) {
 
-		// Safari < 6
 		// exclude useless self-reference for generated Error objects
 		if ( /qunit.js$/.test( e.sourceURL ) ) {
 			return;
@@ -528,16 +523,19 @@ function extractStacktrace( e, offset ) {
 }
 
 function sourceFromStacktrace( offset ) {
-	var e = new Error();
-	if ( !e.stack ) {
+	var error = new Error();
+
+	// Support: Safari <=7 only, IE <=10 - 11 only
+	// Not all browsers generate the `stack` property for `new Error()`, see also #636
+	if ( !error.stack ) {
 		try {
-			throw e;
+			throw error;
 		} catch ( err ) {
-			// This should already be true in most browsers
-			e = err;
+			error = err;
 		}
 	}
-	return extractStacktrace( e, offset );
+
+	return extractStacktrace( error, offset );
 }
 
 function synchronize( callback, last ) {


### PR DESCRIPTION
Ref #758 

I did a test on every supported browser and so far we can drop the `e.stacktrace` part and simplify the way we get the stack information.

The try catch blocks are necessary for IE10 and IE11, otherwise, we could get rid of them.

