### PR TITLE
HTML Reporter: Change display text for bad tests

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -611,7 +611,7 @@ function getNameHtml( name, module ) {
 }
 
 QUnit.testStart(function( details ) {
-	var running, testBlock;
+	var running, testBlock, bad;
 
 	testBlock = id( "qunit-test-output-" + details.testId );
 	if ( testBlock ) {
@@ -624,7 +624,13 @@ QUnit.testStart(function( details ) {
 
 	running = id( "qunit-testresult" );
 	if ( running ) {
-		running.innerHTML = "Running: <br />" + getNameHtml( details.name, details.module );
+		bad = QUnit.config.reorder && defined.sessionStorage &&
+			+sessionStorage.getItem( "qunit-test-" + details.module + "-" + details.name );
+
+		running.innerHTML = ( bad ?
+			"Rerunning previously failed test: <br />" :
+			"Running: <br />" ) +
+			getNameHtml( details.name, details.module );
 	}
 
 });


### PR DESCRIPTION
When displaying text for running tests, if
QUnit.config.reorder is enabled then previously
failed tests will run first. However in summary
there is no indication for the same. This commit
changes the message text in HTML reporter.

Fixes #693