### PR TITLE
Typed arrays comparison with standard arrays

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -17,6 +17,7 @@ var QUnit,
 	defined = {
 		document: window.document !== undefined,
 		setTimeout: window.setTimeout !== undefined,
+		typedArray: typeof( Int8Array ) === "function",
 		sessionStorage: (function() {
 			var x = "qunit-test-string";
 			try {
@@ -348,13 +349,13 @@ extend( QUnit, {
 				return type.toLowerCase();
 		}
 		if ( typeof obj === "object" ) {
-			if ( obj instanceof Int8Array ||
-				obj instanceof Uint8Array ||
-				obj instanceof Int16Array ||
-				obj instanceof Uint16Array ||
-				obj instanceof Int32Array ||
-				obj instanceof Uint32Array ||
-				obj instanceof Float32Array ) {
+			if ( defined.typedArray && obj instanceof Int8Array ||
+					obj instanceof Uint8Array ||
+					obj instanceof Int16Array ||
+					obj instanceof Uint16Array ||
+					obj instanceof Int32Array ||
+					obj instanceof Uint32Array ||
+					obj instanceof Float32Array ) {
 				return "typedarray";
 			}
 

--- a/src/core.js
+++ b/src/core.js
@@ -348,6 +348,16 @@ extend( QUnit, {
 				return type.toLowerCase();
 		}
 		if ( typeof obj === "object" ) {
+			if ( obj instanceof Int8Array ||
+				obj instanceof Uint8Array ||
+				obj instanceof Int16Array ||
+				obj instanceof Uint16Array ||
+				obj instanceof Int32Array ||
+				obj instanceof Uint32Array ||
+				obj instanceof Float32Array ) {
+				return "typedarray";
+			}
+
 			return "object";
 		}
 		return undefined;

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -198,6 +198,15 @@ QUnit.equiv = (function() {
 		}
 
 		return ( (function( a, b ) {
+			// convert typedarrays into real arrays
+			if ( a && QUnit.objectType( a ) === "typedarray" ) {
+				a = Array.prototype.slice.call( a );
+			}
+
+			if ( b && QUnit.objectType( b ) === "typedarray" ) {
+				b = Array.prototype.slice.call( b );
+			}
+
 			if ( a === b ) {
 				return true; // catch the most you can
 			} else if ( a === null || b === null || typeof a === "undefined" ||

--- a/test/deepEqual.js
+++ b/test/deepEqual.js
@@ -157,15 +157,22 @@ QUnit.test( "Objects basics", function( assert ) {
 });
 
 QUnit.test( "Typed arrays", function( assert ) {
-	assert.equal( QUnit.equiv( new Uint8Array(0), new Uint8Array(4) ), false );
-	assert.equal( QUnit.equiv( new Uint8Array(4), new Uint8Array(0) ), false );
-	assert.equal( QUnit.equiv( new Uint8Array(4), new Uint8Array(4) ), true );
-	assert.equal( QUnit.equiv( new Uint8Array(new Uint8Array(4)), new Uint8Array(new Uint8Array(4)) ), true );
+	// Check if typed arrays are supported
+	if ( typeof( Int8Array ) === "function" ) {
+		// Compare typed arrays with typed arrays
+		assert.equal( QUnit.equiv( new Uint8Array(0), new Uint8Array(4) ), false );
+		assert.equal( QUnit.equiv( new Uint8Array(4), new Uint8Array(0) ), false );
+		assert.equal( QUnit.equiv( new Uint8Array(4), new Uint8Array(4) ), true );
+		assert.equal( QUnit.equiv( new Uint8Array(new Uint8Array(4)), new Uint8Array(new Uint8Array(4)) ), true );
 
-	assert.equal( QUnit.equiv( new Uint8Array(4), [] ), false, "typed array vs standard array" );
-	assert.equal( QUnit.equiv( new Uint8Array(4), [0, 0, 0, 0] ), true, "typed array vs standard array" );
-	assert.equal( QUnit.equiv( [0, 0, 0, 0], new Uint8Array(4) ), true, "typed array vs standard array" );
-	assert.equal( QUnit.equiv( [0, 1, 0, 0], new Uint8Array(4) ), false, "typed array vs standard array" );
+		// Compare typed arrays with standard arrays
+		assert.equal( QUnit.equiv( new Uint8Array(4), [] ), false, "typed array vs standard array" );
+		assert.equal( QUnit.equiv( new Uint8Array(4), [0, 0, 0, 0] ), true, "typed array vs standard array" );
+		assert.equal( QUnit.equiv( [0, 0, 0, 0], new Uint8Array(4) ), true, "typed array vs standard array" );
+		assert.equal( QUnit.equiv( [0, 1, 0, 0], new Uint8Array(4) ), false, "typed array vs standard array" );
+	} else {
+		assert.expect(0);
+	}
 
 });
 

--- a/test/deepEqual.js
+++ b/test/deepEqual.js
@@ -156,6 +156,19 @@ QUnit.test( "Objects basics", function( assert ) {
 	}
 });
 
+QUnit.test( "Typed arrays", function( assert ) {
+	assert.equal( QUnit.equiv( new Uint8Array(0), new Uint8Array(4) ), false );
+	assert.equal( QUnit.equiv( new Uint8Array(4), new Uint8Array(0) ), false );
+	assert.equal( QUnit.equiv( new Uint8Array(4), new Uint8Array(4) ), true );
+	assert.equal( QUnit.equiv( new Uint8Array(new Uint8Array(4)), new Uint8Array(new Uint8Array(4)) ), true );
+
+	assert.equal( QUnit.equiv( new Uint8Array(4), [] ), false, "typed array vs standard array" );
+	assert.equal( QUnit.equiv( new Uint8Array(4), [0, 0, 0, 0] ), true, "typed array vs standard array" );
+	assert.equal( QUnit.equiv( [0, 0, 0, 0], new Uint8Array(4) ), true, "typed array vs standard array" );
+	assert.equal( QUnit.equiv( [0, 1, 0, 0], new Uint8Array(4) ), false, "typed array vs standard array" );
+
+});
+
 QUnit.test( "Arrays basics", function( assert ) {
 
 	assert.equal( QUnit.equiv( [], [] ), true );


### PR DESCRIPTION
Allow `deepEqual` comparison of typed arrays and standard arrays. Since phantomjs don't support `Uint8ClampedArray` and `Float64Array` hence they are not present in the comparison.

Fixes #672 