### PR TITLE
HTML Reporter: Show diff only when it helps

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -629,9 +629,15 @@ QUnit.testStart(function( details ) {
 
 });
 
+function stripHtml( string ) {
+	// strip tags, html entity and whitespaces
+	return string.replace(/<\/?[^>]+(>|$)/g, "").replace(/\&quot;/g, "").replace(/\s+/g, "");
+}
+
 QUnit.log(function( details ) {
 	var assertList, assertLi,
-		message, expected, actual,
+		message, expected, actual, diff,
+		lengthChanged = true,
 		testItem = id( "qunit-test-output-" + details.testId );
 
 	if ( !testItem ) {
@@ -653,10 +659,16 @@ QUnit.log(function( details ) {
 			"</pre></td></tr>";
 
 		if ( actual !== expected ) {
+			diff = QUnit.diff( expected, actual );
+			lengthChanged = stripHtml( diff ).length !==
+				stripHtml( expected ).length +
+				stripHtml( actual ).length;
+
+			// don't show diff if expected and actual are totally different
 			message += "<tr class='test-actual'><th>Result: </th><td><pre>" +
 				actual + "</pre></td></tr>" +
-				"<tr class='test-diff'><th>Diff: </th><td><pre>" +
-				QUnit.diff( expected, actual ) + "</pre></td></tr>";
+				( lengthChanged ? "<tr class='test-diff'><th>Diff: </th><td><pre>" +
+					diff + "</pre></td></tr>" : "" );
 		}
 
 		if ( details.source ) {


### PR DESCRIPTION
Don't show diff if expected and actual values are completely different and there is nothing in common.

However when working with two different arrays or objects, the braces remains common because of which the length changes and diff is displayed. Is this behavior accepted? It works fine if we compare object and array. Screenshot attached:

![qunit](https://cloud.githubusercontent.com/assets/3061095/6680039/e130853e-cc77-11e4-9fbc-2719cfe8a49e.png)

Fixes #335