### PR TITLE
HTML Reporter: Escape backslash when parsing string

### DIFF
--- a/src/dump.js
+++ b/src/dump.js
@@ -2,7 +2,7 @@
 // http://flesler.blogspot.com/2008/05/jsdump-pretty-dump-of-any-javascript.html
 QUnit.dump = (function() {
 	function quote( str ) {
-		return "\"" + str.toString().replace( /"/g, "\\\"" ) + "\"";
+		return "\"" + str.toString().replace( /\\/g, "\\\\" ).replace( /"/g, "\\\"" ) + "\"";
 	}
 	function literal( o ) {
 		return o + "";


### PR DESCRIPTION
Screenshot:
![qunit](https://cloud.githubusercontent.com/assets/3061095/6763805/33978b62-cfb4-11e4-9881-482a28ce70e1.png)


Fixes #478 