### PR TITLE
HTML Reporter: Make it more obvious why diff is suppressed

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -668,7 +668,7 @@ QUnit.log(function( details ) {
 					expected.indexOf( "[object Object]" ) !== -1 ) {
 				message += "<tr class='test-message'><th>Message: </th><td>" +
 					"Diff suppressed as the depth of object is more than current max depth (" +
-					QUnit.config.maxDepth + ").<p>Hint: Use 'QUnit.config.maxDepth' to run " +
+					QUnit.config.maxDepth + ").<p>Hint: Use 'QUnit.dump.maxDepth' to run " +
 					" with a higher max depth or <a href='?maxDepth=-1'>" +
 					"Rerun</a> without max depth</p></td></tr>";
 			}

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -668,8 +668,8 @@ QUnit.log(function( details ) {
 					expected.indexOf( "[object Object]" ) !== -1 ) {
 				message += "<tr class='test-message'><th>Message: </th><td>" +
 					"Diff suppressed as the depth of object is more than current max depth (" +
-					QUnit.config.maxDepth + ").<p>Hint: Use 'QUnit.dump.maxDepth' to run " +
-					" with a higher max depth or <a href='?maxDepth=-1'>" +
+					QUnit.config.maxDepth + ").<p>Hint: Use <code>QUnit.dump.maxDepth</code> to " +
+					" run with a higher max depth or <a href='" + setUrl({ maxDepth: -1 }) + "'>" +
 					"Rerun</a> without max depth</p></td></tr>";
 			}
 		}

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -663,6 +663,12 @@ QUnit.log(function( details ) {
 				actual + "</pre></td></tr>" +
 				"<tr class='test-diff'><th>Diff: </th><td><pre>" +
 				QUnit.diff( expected, actual ) + "</pre></td></tr>";
+		} else {
+			if ( expected.indexOf( "[object Array]" ) !== -1 ||
+					expected.indexOf( "[object Object]" ) !== -1 ) {
+				message += "<tr class='test-message'><th>Message: </th><td>" +
+					"Diff suppressed as depth of object is more than max depth. </td></tr>";
+			}
 		}
 
 		if ( details.source ) {

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -667,7 +667,10 @@ QUnit.log(function( details ) {
 			if ( expected.indexOf( "[object Array]" ) !== -1 ||
 					expected.indexOf( "[object Object]" ) !== -1 ) {
 				message += "<tr class='test-message'><th>Message: </th><td>" +
-					"Diff suppressed as depth of object is more than max depth. </td></tr>";
+					"Diff suppressed as the depth of object is more than current max depth (" +
+					QUnit.config.maxDepth + ").<p>Hint: Use 'QUnit.config.maxDepth' to run " +
+					" with a higher max depth or <a href='?maxDepth=-1'>" +
+					"Rerun</a> without max depth</p></td></tr>";
 			}
 		}
 

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -670,7 +670,7 @@ QUnit.log(function( details ) {
 					"Diff suppressed as the depth of object is more than current max depth (" +
 					QUnit.config.maxDepth + ").<p>Hint: Use <code>QUnit.dump.maxDepth</code> to " +
 					" run with a higher max depth or <a href='" + setUrl({ maxDepth: -1 }) + "'>" +
-					"Rerun</a> without max depth</p></td></tr>";
+					"Rerun</a> without max depth.</p></td></tr>";
 			}
 		}
 

--- a/src/core.js
+++ b/src/core.js
@@ -103,6 +103,9 @@ config = {
 	// when enabled, all tests must call expect()
 	requireExpects: false,
 
+	// depth up-to which object will be dumped
+	maxDepth: 5,
+
 	// add checkboxes that are persisted in the query-string
 	// when enabled, the id is set to `true` as a `QUnit.config` property
 	urlConfig: [
@@ -171,6 +174,12 @@ config.modules.push( config.currentModule );
 
 	// String search anywhere in moduleName+testName
 	config.filter = urlParams.filter;
+
+	if ( urlParams.maxDepth ) {
+		config.maxDepth = parseInt( urlParams.maxDepth, 10 ) === -1 ?
+			Number.POSITIVE_INFINITY :
+			urlParams.maxDepth;
+	}
 
 	config.testId = [];
 	if ( urlParams.testId ) {

--- a/src/dump.js
+++ b/src/dump.js
@@ -127,7 +127,7 @@ QUnit.dump = (function() {
 			join: join,
 			//
 			depth: 1,
-			maxDepth: 5,
+			maxDepth: QUnit.config.maxDepth,
 
 			// This is the list of parsers, to modify them, use dump.setParser
 			parsers: {

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -137,6 +137,11 @@
 	color: #C2CCD1;
 	text-decoration: none;
 }
+
+#qunit-tests li p a {
+	padding: 0.25em;
+    color: #6B6464;
+}
 #qunit-tests li a:hover,
 #qunit-tests li a:focus {
 	color: #000;

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -140,7 +140,7 @@
 
 #qunit-tests li p a {
 	padding: 0.25em;
-    color: #6B6464;
+	color: #6B6464;
 }
 #qunit-tests li a:hover,
 #qunit-tests li a:focus {


### PR DESCRIPTION
If the depth of an object is more than 'Max Depth' specified in `Qunit.dump` then the diff is not displayed. This behavior is confusing. This PR will display a message to the user so that user knows why it is not displayed.

Refer: https://github.com/jquery/qunit/issues/793#issuecomment-84495125

I'm confused with what text to display to the user since the user might not be aware of max depth. Any suggestions?

Screenshot:
![qunit4](https://cloud.githubusercontent.com/assets/3061095/6769225/271d3fc6-d0b8-11e4-9bf2-c135690cbfac.png)
