### PR TITLE
HTML Reporter: Display only the different part in diff

### DIFF
--- a/src/qunit.css
+++ b/src/qunit.css
@@ -289,3 +289,9 @@
 	width: 1000px;
 	height: 1000px;
 }
+
+/** Diff */
+
+.blob-code {
+	background-color: #ebebeb;
+}


### PR DESCRIPTION
This is a very basic implementation.
Here the diff removes the unnesseray part (in big objects or arrays), and only displays the diff part.
It is like the github's diff, where common parts are hidden and only diff is seen.

Also there is no styling done
This PR is mostly for feedbacks.