### PR TITLE
CSS: Fix for #737

### DIFF
--- a/src/qunit.css
+++ b/src/qunit.css
@@ -117,6 +117,7 @@
 #qunit-tests.hidepass li.running,
 #qunit-tests.hidepass li.pass {
 	visibility: hidden;
+	position: absolute;
 	width:   0px;
 	height:  0px;
 	padding: 0;


### PR DESCRIPTION
Closes: https://github.com/jquery/qunit/issues/771

Before:
![beforecss](https://cloud.githubusercontent.com/assets/6555434/6939167/515eacbc-d887-11e4-82b8-57a62393d933.png)

After:
![aftercss](https://cloud.githubusercontent.com/assets/6555434/6939170/573f9efc-d887-11e4-9aac-5ab787869648.png)

@jzaefferer Please Review