### PR TITLE
Build: Remove Opera 12.1 from browserstack tests

### DIFF
--- a/browserstack.json
+++ b/browserstack.json
@@ -14,7 +14,6 @@
 		"chrome_current",
 		"firefox_previous",
 		"firefox_current",
-		"opera_12_1",
 		"opera_previous",
 		"opera_current",
 		"safari_5_1",


### PR DESCRIPTION
Although the support is not over, the browserstack tests on that browser
is returning some random errors on Travis-CI, which might be due to
timeout errors, common sometimes, but with a misleading feedback.

Ref #785