### PR TITLE
Tests: Avoid loosen errors on autostart test

### DIFF
--- a/browserstack.json
+++ b/browserstack.json
@@ -8,6 +8,7 @@
 		"test/logs.html",
 		"test/setTimeout.html",
 		"test/amd.html",
+		"test/autostart.html",
 		"test/reporter-html/index.html"
 	],
 	"browsers": [

--- a/test/autostart.html
+++ b/test/autostart.html
@@ -10,35 +10,26 @@
 	<script src="../dist/qunit.js"></script>
 	<script>
 	var beginData,
-		asyncDelay = 1000,
-		times = {
-			autostartOff: 0,
-			pageLoaded: 0,
-			runStarted: 0
-		};
+		times = {};
 
 	(function() {
 		var now = Date.now || function() {
 			return new Date().getTime();
 		};
+		var asyncDelay = 1000;
 
 		QUnit.config.autostart = false;
 
 		// Mark the current time
-		times.autostartOff = now();
+		times.autostartOff = now() + asyncDelay;
 
 		// Simulate a delay in loading the tests, as when they are loaded
 		// asynchronously using requirejs, steal, etc.
 		setTimeout(function() {
 			var script = document.createElement( "script" );
 			script.src = "autostart.js";
-			document.getElementsByTagName( "head" )[0].appendChild( script );
+			document.getElementsByTagName( "head" )[ 0 ].appendChild( script );
 		}, asyncDelay );
-
-		QUnit.load = (function( _load ) {
-			times.pageLoaded = now();
-			_load.call( QUnit );
-		})( QUnit.load );
 
 		QUnit.begin(function( data ) {
 			beginData = data;

--- a/test/autostart.js
+++ b/test/autostart.js
@@ -1,13 +1,11 @@
-/*global asyncDelay, times, beginData */
+/*global times, beginData */
 
 QUnit.start();
 
 QUnit.module( "autostart" );
 
 QUnit.test( "Prove the test run started as expected", function( assert ) {
-	assert.expect( 4 );
-	assert.ok( times.autostartOff <= times.pageLoaded );
-	assert.ok( times.pageLoaded <= times.runStarted );
-	assert.ok( times.autostartOff + asyncDelay <= times.runStarted );
+	assert.expect( 2 );
+	assert.ok( times.autostartOff <= times.runStarted );
 	assert.strictEqual( beginData.totalTests, 1, "Should have expected 1 test" );
 });


### PR DESCRIPTION
Also remove the QUnit.load as they were invalid.

Closes #798
Closes #803