### PR TITLE
Core: Optimize utilization of global and window variables

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,6 +140,8 @@ grunt.registerTask( "test-on-node", function() {
 		done = this.async(),
 		QUnit = require( "./dist/qunit" );
 
+	global.QUnit = QUnit;
+
 	QUnit.testStart(function() {
 		testActive = true;
 	});
@@ -178,7 +180,6 @@ grunt.registerTask( "test-on-node", function() {
 	require( "./test/main/promise" );
 	require( "./test/main/modules" );
 	require( "./test/main/deepEqual" );
-	require( "./test/main/globals" );
 	require( "./test/main/stack" );
 	require( "./test/globals-node" );
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,10 +26,12 @@ grunt.initConfig({
 			options: { process: process },
 			src: [
 				"src/intro.js",
+				"src/core/initialize.js",
 				"src/core/utilities.js",
 				"src/core/stacktrace.js",
 				"src/core/config.js",
 				"src/core/logging.js",
+				"src/core/onerror.js",
 				"src/core.js",
 				"src/test.js",
 				"src/assert.js",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,8 +38,8 @@ grunt.initConfig({
 				"src/equiv.js",
 				"src/dump.js",
 				"src/export.js",
-				"src/outro.js",
 				"src/diff.js",
+				"src/outro.js",
 				"reporter/html.js"
 			],
 			dest: "dist/qunit.js"

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -1,5 +1,10 @@
 (function() {
 
+// Don't load the HTML Reporter on non-Browser environments
+if ( typeof window === "undefined" || !window.document ) {
+	return;
+}
+
 // Deprecated QUnit.init - Ref #530
 // Re-initialize the configuration options
 QUnit.init = function() {
@@ -56,11 +61,6 @@ QUnit.init = function() {
 		result.innerHTML = "Running...<br />&#160;";
 	}
 };
-
-// Don't load the HTML Reporter on non-Browser environments
-if ( typeof window === "undefined" ) {
-	return;
-}
 
 var config = QUnit.config,
 	hasOwn = Object.prototype.hasOwnProperty,

--- a/src/core.js
+++ b/src/core.js
@@ -1,19 +1,7 @@
-var QUnit,
-	onErrorFnPrev,
-	fileName = ( sourceFromStacktrace( 0 ) || "" ).replace( /(:\d+)+\)?/, "" ).replace( /.+\//, "" ),
-	globalStartCalled = false,
-	runStarted = false,
-	Date = window.Date,
-	now = Date.now || function() {
-		return new Date().getTime();
-	},
-	location = window.location || { search: "", protocol: "file:" };
-
-QUnit = {};
-
 QUnit.urlParams = urlParams;
 
-QUnit.isLocal = location.protocol === "file:";
+// Figure out if we're running the tests from a server or not
+QUnit.isLocal = !( defined.document && window.location.protocol !== "file:" );
 
 // Expose the current QUnit version
 QUnit.version = "@VERSION";
@@ -145,38 +133,6 @@ extend( QUnit, {
 });
 
 registerLoggingCallbacks( QUnit );
-
-// `onErrorFnPrev` initialized at top of scope
-// Preserve other handlers
-onErrorFnPrev = window.onerror;
-
-// Cover uncaught exceptions
-// Returning true will suppress the default browser handler,
-// returning false will let it run.
-window.onerror = function( error, filePath, linerNr ) {
-	var ret = false;
-	if ( onErrorFnPrev ) {
-		ret = onErrorFnPrev( error, filePath, linerNr );
-	}
-
-	// Treat return value as window.onerror itself does,
-	// Only do our handling if not suppressed.
-	if ( ret !== true ) {
-		if ( QUnit.config.current ) {
-			if ( QUnit.config.current.ignoreGlobalErrors ) {
-				return true;
-			}
-			QUnit.pushFailure( error, filePath + ":" + linerNr );
-		} else {
-			QUnit.test( "global failure", extend(function() {
-				QUnit.pushFailure( error, filePath + ":" + linerNr );
-			}, { validTest: true } ) );
-		}
-		return false;
-	}
-
-	return ret;
-};
 
 function begin() {
 	var i, l,

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -38,7 +38,7 @@ var config = {
 			id: "noglobals",
 			label: "Check for Globals",
 			tooltip: "Enabling this will test if any test introduces new properties on the " +
-				"`window` object. Stored as query-strings."
+				"global object (`window` in Browsers). Stored as query-strings."
 		},
 		{
 			id: "notrycatch",
@@ -58,8 +58,9 @@ var config = {
 	},
 
 	callbacks: {}
-},
-	urlParams = getUrlParams();
+};
+
+var urlParams = defined.document ? getUrlParams() : {};
 
 // Push a loose unnamed module to the modules collection
 config.modules.push( config.currentModule );

--- a/src/core/initialize.js
+++ b/src/core/initialize.js
@@ -2,8 +2,8 @@ var QUnit = {};
 
 var Date = global.Date;
 var now = Date.now || function() {
-			return new Date().getTime();
-		};
+	return new Date().getTime();
+};
 
 var setTimeout = global.setTimeout;
 var clearTimeout = global.clearTimeout;

--- a/src/core/initialize.js
+++ b/src/core/initialize.js
@@ -1,0 +1,31 @@
+var QUnit = {};
+
+var Date = global.Date;
+var now = Date.now || function() {
+			return new Date().getTime();
+		};
+
+var setTimeout = global.setTimeout;
+var clearTimeout = global.clearTimeout;
+
+// Store a local window from the global to allow direct references.
+var window = global.window;
+
+var defined = {
+	document: window && window.document !== undefined,
+	setTimeout: setTimeout !== undefined,
+	sessionStorage: (function() {
+		var x = "qunit-test-string";
+		try {
+			sessionStorage.setItem( x, x );
+			sessionStorage.removeItem( x );
+			return true;
+		} catch ( e ) {
+			return false;
+		}
+	}() )
+};
+
+var fileName = ( sourceFromStacktrace( 0 ) || "" ).replace( /(:\d+)+\)?/, "" ).replace( /.+\//, "" );
+var globalStartCalled = false;
+var runStarted = false;

--- a/src/core/logging.js
+++ b/src/core/logging.js
@@ -63,8 +63,8 @@ function verifyLoggingCallbacks() {
 			// Assign the deprecated given callback
 			QUnit[ loggingCallback ]( userCallback );
 
-			if ( window.console && window.console.warn ) {
-				window.console.warn(
+			if ( global.console && global.console.warn ) {
+				global.console.warn(
 					"QUnit." + loggingCallback + " was replaced with a new value.\n" +
 					"Please, check out the documentation on how to apply logging callbacks.\n" +
 					"Reference: http://api.qunitjs.com/category/callbacks/"

--- a/src/core/onerror.js
+++ b/src/core/onerror.js
@@ -1,4 +1,7 @@
-if ( defined.document ) {
+( function() {
+	if ( !defined.document ) {
+		return;
+	}
 
 	// `onErrorFnPrev` initialized at top of scope
 	// Preserve other handlers
@@ -31,4 +34,4 @@ if ( defined.document ) {
 
 		return ret;
 	};
-}
+} )();

--- a/src/core/onerror.js
+++ b/src/core/onerror.js
@@ -1,0 +1,34 @@
+if ( defined.document ) {
+
+	// `onErrorFnPrev` initialized at top of scope
+	// Preserve other handlers
+	var onErrorFnPrev = window.onerror;
+
+	// Cover uncaught exceptions
+	// Returning true will suppress the default browser handler,
+	// returning false will let it run.
+	window.onerror = function( error, filePath, linerNr ) {
+		var ret = false;
+		if ( onErrorFnPrev ) {
+			ret = onErrorFnPrev( error, filePath, linerNr );
+		}
+
+		// Treat return value as window.onerror itself does,
+		// Only do our handling if not suppressed.
+		if ( ret !== true ) {
+			if ( QUnit.config.current ) {
+				if ( QUnit.config.current.ignoreGlobalErrors ) {
+					return true;
+				}
+				QUnit.pushFailure( error, filePath + ":" + linerNr );
+			} else {
+				QUnit.test( "global failure", extend(function() {
+					QUnit.pushFailure( error, filePath + ":" + linerNr );
+				}, { validTest: true } ) );
+			}
+			return false;
+		}
+
+		return ret;
+	};
+}

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -1,7 +1,5 @@
 var toString = Object.prototype.toString,
-	hasOwn = Object.prototype.hasOwnProperty,
-	setTimeout = window.setTimeout,
-	clearTimeout = window.clearTimeout;
+	hasOwn = Object.prototype.hasOwnProperty;
 
 // returns a new Array with the elements that are in a but not in b
 function diff( a, b ) {
@@ -59,7 +57,7 @@ function extend( a, b, undefOnly ) {
 		if ( hasOwn.call( b, prop ) ) {
 
 			// Avoid "Member not found" error in IE8 caused by messing with window.constructor
-			if ( !( prop === "constructor" && a === window ) ) {
+			if ( !( prop === "constructor" && a === global ) ) {
 				if ( b[ prop ] === undefined ) {
 					delete a[ prop ];
 				} else if ( !( undefOnly && typeof a[ prop ] !== "undefined" ) ) {
@@ -113,11 +111,12 @@ function is( type, obj ) {
 }
 
 var getUrlParams = function() {
-	var i, current,
-		location = window.location || { search: "", protocol: "file:" },
-		params = location.search.slice( 1 ).split( "&" ),
-		length = params.length,
-		urlParams = {};
+	var i, current, location, params, length;
+	var urlParams = {};
+
+	location = window.location;
+	params = location.search.slice( 1 ).split( "&" );
+	length = params.length;
 
 	if ( params[ 0 ] ) {
 		for ( i = 0; i < length; i++ ) {
@@ -135,19 +134,4 @@ var getUrlParams = function() {
 	}
 
 	return urlParams;
-};
-
-var defined = {
-	document: window.document !== undefined,
-	setTimeout: setTimeout !== undefined,
-	sessionStorage: (function() {
-		var x = "qunit-test-string";
-		try {
-			sessionStorage.setItem( x, x );
-			sessionStorage.removeItem( x );
-			return true;
-		} catch ( e ) {
-			return false;
-		}
-	}() )
 };

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -57,7 +57,7 @@ function extend( a, b, undefOnly ) {
 		if ( hasOwn.call( b, prop ) ) {
 
 			// Avoid "Member not found" error in IE8 caused by messing with window.constructor
-			if ( !( prop === "constructor" && a === global ) ) {
+			if ( prop !== "constructor" || a !== global ) {
 				if ( b[ prop ] === undefined ) {
 					delete a[ prop ];
 				} else if ( !( undefOnly && typeof a[ prop ] !== "undefined" ) ) {
@@ -111,12 +111,11 @@ function is( type, obj ) {
 }
 
 var getUrlParams = function() {
-	var i, current, location, params, length;
+	var i, current;
 	var urlParams = {};
-
-	location = window.location;
-	params = location.search.slice( 1 ).split( "&" );
-	length = params.length;
+	var location = window.location;
+	var params = location.search.slice( 1 ).split( "&" );
+	var length = params.length;
 
 	if ( params[ 0 ] ) {
 		for ( i = 0; i < length; i++ ) {

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -57,6 +57,8 @@ function extend( a, b, undefOnly ) {
 		if ( hasOwn.call( b, prop ) ) {
 
 			// Avoid "Member not found" error in IE8 caused by messing with window.constructor
+			// This block runs on every environment, so `global` is being used instead of `window`
+			// to avoid errors on node.
 			if ( prop !== "constructor" || a !== global ) {
 				if ( b[ prop ] === undefined ) {
 					delete a[ prop ];

--- a/src/export.js
+++ b/src/export.js
@@ -1,5 +1,5 @@
 // For browser, export only select globals
-if ( typeof window !== "undefined" && window.document !== "undefined" ) {
+if ( defined.document ) {
 
 	// Deprecated
 	// Extend assert methods to QUnit and Global scope through Backwards compatibility

--- a/src/export.js
+++ b/src/export.js
@@ -1,5 +1,5 @@
 // For browser, export only select globals
-if ( typeof window !== "undefined" ) {
+if ( typeof window !== "undefined" && window.document !== "undefined" ) {
 
 	// Deprecated
 	// Extend assert methods to QUnit and Global scope through Backwards compatibility

--- a/src/intro.js
+++ b/src/intro.js
@@ -9,4 +9,4 @@
  * Date: @DATE
  */
 
-(function( window ) {
+(function( global ) {

--- a/src/test.js
+++ b/src/test.js
@@ -398,7 +398,7 @@ QUnit.reset = function() {
 
 	// Return on non-browser environments
 	// This is necessary to not break on node tests
-	if ( typeof window === "undefined" ) {
+	if ( !defined.document ) {
 		return;
 	}
 
@@ -464,8 +464,8 @@ function saveGlobal() {
 	config.pollution = [];
 
 	if ( config.noglobals ) {
-		for ( var key in window ) {
-			if ( hasOwn.call( window, key ) ) {
+		for ( var key in global ) {
+			if ( hasOwn.call( global, key ) ) {
 
 				// in Opera sometimes DOM element ids show up here, ignore them
 				if ( /^qunit-test-output/.test( key ) ) {


### PR DESCRIPTION
Ref #790

QUnit was found exported to the global object on Node environment.

This PR also removes QUnit.diff and QUnit.init functions on Node, they were always browser functions.

This might look as a breaking change, so we should also discuss if this if good to land only on 2.0 or maybe I could set a stub function for them printing a warning about their usage on non-browser envs, which is not functional.