### PR TITLE
HTML Reporter: HTML reporter enhancements for negative asserts

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -652,11 +652,11 @@ QUnit.log(function( details ) {
 	// when it calls, it's implicit to also not show expected and diff stuff
 	// Also, we need to check details.expected existence, as it can exist and be undefined
 	if ( !details.result && hasOwn.call( details, "expected" ) ) {
-        if ( details.negative ) {
-            expected = escapeText( "NOT " + QUnit.dump.parse( details.expected ) );
-        } else {
-            expected = escapeText( QUnit.dump.parse( details.expected ) );
-        }
+		if ( details.negative ) {
+			expected = escapeText( "NOT " + QUnit.dump.parse( details.expected ) );
+		} else {
+			expected = escapeText( QUnit.dump.parse( details.expected ) );
+		}
 
 		actual = escapeText( QUnit.dump.parse( details.actual ) );
 		message += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" +

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -652,7 +652,12 @@ QUnit.log(function( details ) {
 	// when it calls, it's implicit to also not show expected and diff stuff
 	// Also, we need to check details.expected existence, as it can exist and be undefined
 	if ( !details.result && hasOwn.call( details, "expected" ) ) {
-		expected = escapeText( QUnit.dump.parse( details.expected ) );
+        if ( details.negative ) {
+            expected = escapeText( "NOT " + QUnit.dump.parse( details.expected ) );
+        } else {
+            expected = escapeText( QUnit.dump.parse( details.expected ) );
+        }
+
 		actual = escapeText( QUnit.dump.parse( details.actual ) );
 		message += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" +
 			expected +

--- a/src/assert.js
+++ b/src/assert.js
@@ -38,7 +38,7 @@ QUnit.assert = Assert.prototype = {
 	},
 
 	// Exports test.push() to the user API
-	push: function( /* result, actual, expected, message */ ) {
+	push: function( /* result, actual, expected, message, negative */ ) {
 		var assert = this,
 			currentTest = ( assert instanceof Assert && assert.test ) || QUnit.config.current;
 
@@ -73,7 +73,7 @@ QUnit.assert = Assert.prototype = {
 	notOk: function( result, message ) {
 		message = message || ( !result ? "okay" : "failed, expected argument to be falsy, was: " +
 			QUnit.dump.parse( result ) );
-		this.push( !result, result, false, message );
+		this.push( !result, result, false, message, true );
 	},
 
 	equal: function( actual, expected, message ) {
@@ -83,7 +83,7 @@ QUnit.assert = Assert.prototype = {
 
 	notEqual: function( actual, expected, message ) {
 		/*jshint eqeqeq:false */
-		this.push( expected != actual, actual, expected, message );
+		this.push( expected != actual, actual, expected, message, true );
 	},
 
 	propEqual: function( actual, expected, message ) {
@@ -95,7 +95,7 @@ QUnit.assert = Assert.prototype = {
 	notPropEqual: function( actual, expected, message ) {
 		actual = objectValues( actual );
 		expected = objectValues( expected );
-		this.push( !QUnit.equiv( actual, expected ), actual, expected, message );
+		this.push( !QUnit.equiv( actual, expected ), actual, expected, message, true );
 	},
 
 	deepEqual: function( actual, expected, message ) {
@@ -103,7 +103,7 @@ QUnit.assert = Assert.prototype = {
 	},
 
 	notDeepEqual: function( actual, expected, message ) {
-		this.push( !QUnit.equiv( actual, expected ), actual, expected, message );
+		this.push( !QUnit.equiv( actual, expected ), actual, expected, message, true );
 	},
 
 	strictEqual: function( actual, expected, message ) {
@@ -111,7 +111,7 @@ QUnit.assert = Assert.prototype = {
 	},
 
 	notStrictEqual: function( actual, expected, message ) {
-		this.push( expected !== actual, actual, expected, message );
+		this.push( expected !== actual, actual, expected, message, true );
 	},
 
 	"throws": function( block, expected, message ) {

--- a/src/test.js
+++ b/src/test.js
@@ -262,7 +262,7 @@ Test.prototype = {
 		}
 	},
 
-	push: function( result, actual, expected, message ) {
+	push: function( result, actual, expected, message, negative ) {
 		var source,
 			details = {
 				module: this.module.name,
@@ -272,6 +272,7 @@ Test.prototype = {
 				actual: actual,
 				expected: expected,
 				testId: this.testId,
+                negative: negative || false,
 				runtime: now() - this.started
 			};
 

--- a/src/test.js
+++ b/src/test.js
@@ -272,7 +272,7 @@ Test.prototype = {
 				actual: actual,
 				expected: expected,
 				testId: this.testId,
-                negative: negative || false,
+				negative: negative || false,
 				runtime: now() - this.started
 			};
 

--- a/test/logs.js
+++ b/test/logs.js
@@ -114,7 +114,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 		message: "log runtime was a reasonable number",
 		actual: true,
 		expected: true,
-        negative: false,
+		negative: false,
 		testId: module1Test1.testId
 	}, "log context after equal(actual, expected, message)" );
 
@@ -128,7 +128,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 		message: undefined,
 		actual: "foo",
 		expected: "foo",
-        negative: false,
+		negative: false,
 		testId: module1Test1.testId
 	}, "log context after equal(actual, expected)" );
 
@@ -142,7 +142,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 		message: "ok(true, message)",
 		actual: true,
 		expected: true,
-        negative: false,
+		negative: false,
 		testId: module1Test1.testId
 	}, "log context after ok(true, message)" );
 

--- a/test/logs.js
+++ b/test/logs.js
@@ -114,6 +114,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 		message: "log runtime was a reasonable number",
 		actual: true,
 		expected: true,
+        negative: false,
 		testId: module1Test1.testId
 	}, "log context after equal(actual, expected, message)" );
 
@@ -127,6 +128,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 		message: undefined,
 		actual: "foo",
 		expected: "foo",
+        negative: false,
 		testId: module1Test1.testId
 	}, "log context after equal(actual, expected)" );
 
@@ -140,6 +142,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 		message: "ok(true, message)",
 		actual: true,
 		expected: true,
+        negative: false,
 		testId: module1Test1.testId
 	}, "log context after ok(true, message)" );
 

--- a/test/reporter-html/index.html
+++ b/test/reporter-html/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit HTML Reporter Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
+	<link rel="stylesheet" href="../../dist/qunit.css">
 	<script src="../../dist/qunit.js"></script>
 	<script src="reporter-html.js"></script>
 	<script src="../swarminject.js"></script>


### PR DESCRIPTION
HTML reporter will prepend "NOT" to expected value for notEqual, notStrictEqual, notDeepEqual, and notPropEqual assertions.

In addition, notOk assertions are also marked as negative for consistency, though the HTML reporter special-cases that assertion.