### PR TITLE
Added ES6 Set and Map support

### DIFF
--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -94,6 +94,8 @@ function objectType( obj ) {
 		case "String":
 		case "Boolean":
 		case "Array":
+		case "Set":
+		case "Map":
 		case "Date":
 		case "RegExp":
 		case "Function":

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -129,12 +129,12 @@ QUnit.equiv = (function() {
 				
 				"set": function( b, a ) {
 					var aArray, bArray;
-					
+
 					// b could be an object literal here
 					if ( QUnit.objectType( b ) !== "set" ) {
 						return false;
 					}
-					
+
 					// reduce sets to arrays
 					aArray = [];
 					a.forEach( function( v ) {
@@ -144,18 +144,18 @@ QUnit.equiv = (function() {
 					b.forEach( function( v ) {
 						bArray.push(v);
 					});
-					
+
 					return innerEquiv( bArray, aArray );
 				},
 				
 				"map": function( b, a ) {
 					var aArray, bArray;
-					
+
 					// b could be an object literal here
 					if ( QUnit.objectType( b ) !== "map" ) {
 						return false;
 					}
-					
+
 					// reduce sets to arrays
 					aArray = [];
 					a.forEach( function( v, k ) {
@@ -165,7 +165,7 @@ QUnit.equiv = (function() {
 					b.forEach( function( v, k ) {
 						bArray.push([k, v]);
 					});
-					
+
 					return innerEquiv( bArray, aArray );
 				},
 

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -126,6 +126,48 @@ QUnit.equiv = (function() {
 					parentsB.pop();
 					return true;
 				},
+				
+				"set": function( b, a ) {
+					var aArray, bArray;
+					
+					// b could be an object literal here
+					if ( QUnit.objectType( b ) !== "set" ) {
+						return false;
+					}
+					
+					// reduce sets to arrays
+					aArray = [];
+					a.forEach( function( v ) {
+						aArray.push(v);
+					});
+					bArray = [];
+					b.forEach( function( v ) {
+						bArray.push(v);
+					});
+					
+					return innerEquiv( bArray, aArray );
+				},
+				
+				"map": function( b, a ) {
+					var aArray, bArray;
+					
+					// b could be an object literal here
+					if ( QUnit.objectType( b ) !== "map" ) {
+						return false;
+					}
+					
+					// reduce sets to arrays
+					aArray = [];
+					a.forEach( function( v, k ) {
+						aArray.push([k, v]);
+					});
+					bArray = [];
+					b.forEach( function( v, k ) {
+						bArray.push([k, v]);
+					});
+					
+					return innerEquiv( bArray, aArray );
+				},
 
 				"object": function( b, a ) {
 

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -130,7 +130,7 @@ QUnit.equiv = (function() {
 				"set": function( b, a ) {
 					var aArray, bArray;
 
-					// b could be an object literal here
+					// b could be any object here
 					if ( QUnit.objectType( b ) !== "set" ) {
 						return false;
 					}
@@ -150,7 +150,7 @@ QUnit.equiv = (function() {
 				"map": function( b, a ) {
 					var aArray, bArray;
 
-					// b could be an object literal here
+					// b could be any object here
 					if ( QUnit.objectType( b ) !== "map" ) {
 						return false;
 					}

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -126,7 +126,7 @@ QUnit.equiv = (function() {
 					parentsB.pop();
 					return true;
 				},
-				
+
 				"set": function( b, a ) {
 					var aArray, bArray;
 
@@ -146,7 +146,7 @@ QUnit.equiv = (function() {
 
 					return innerEquiv( bArray, aArray );
 				},
-				
+
 				"map": function( b, a ) {
 					var aArray, bArray;
 
@@ -157,11 +157,11 @@ QUnit.equiv = (function() {
 
 					aArray = [];
 					a.forEach( function( v, k ) {
-						aArray.push([k, v]);
+						aArray.push( [ k, v ] );
 					});
 					bArray = [];
 					b.forEach( function( v, k ) {
-						bArray.push([k, v]);
+						bArray.push( [ k, v ] );
 					});
 
 					return innerEquiv( bArray, aArray );

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -135,7 +135,6 @@ QUnit.equiv = (function() {
 						return false;
 					}
 
-					// reduce sets to arrays
 					aArray = [];
 					a.forEach( function( v ) {
 						aArray.push(v);
@@ -156,7 +155,6 @@ QUnit.equiv = (function() {
 						return false;
 					}
 
-					// reduce sets to arrays
 					aArray = [];
 					a.forEach( function( v, k ) {
 						aArray.push([k, v]);

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1531,24 +1531,44 @@ QUnit.test( "Test that must be done at the end because they extend some primitiv
 
 QUnit.module( "equiv Maps and Sets");
 
-// - in IE 11, QUnit.objectType( new Set() ) === "object"
 var hasES6Set = (function() {
 	if ( typeof Set !== "function" ) {
 		return false;
 	}
 
-	var s = new Set();
-	return ( QUnit.objectType( s ) === "set" );
+	try {
+		// some platforms don't support iterables in Set constructors
+		var s = new Set([ 1, 2, 3 ]);
+		if ( s.size !== 3 || !s.has( 2 ) ) {
+			return false;
+		}
+		
+		// in IE 11, QUnit.objectType( new Set() ) === "object"
+		return ( QUnit.objectType( s ) === "set" );
+	}
+	catch (e) {
+		return false;
+	}
 })();
 
-// - in IE 11, QUnit.objectType( new Map() ) === "object"
 var hasES6Map = (function() {
 	if ( typeof Map !== "function" ) {
 		return false;
 	}
 
-	var m = new Map();
-	return ( QUnit.objectType( m ) === "map" );
+	try {
+		// some platforms don't support array-like iterables in Map constructors
+		var m = new Map([ [ 1, 2 ] ]);
+		if ( m.size !== 2 || !m.has( 1 ) ) {
+			return false;
+		}
+		
+		// in IE 11, QUnit.objectType( new Map() ) === "object"
+		return ( QUnit.objectType( m ) === "map" );
+	}
+	catch (e) {
+		return false;
+	}
 })();
 
 QUnit[ hasES6Set ? "test" : "skip" ]( "Sets", function ( assert ) {

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1531,24 +1531,24 @@ QUnit.test( "Test that must be done at the end because they extend some primitiv
 
 QUnit.module( "equiv Maps and Sets");
 
-//  - in IE 11, QUnit.objectType( new Set() ) === 'object'
+// - in IE 11, QUnit.objectType( new Set() ) === "object"
 var hasES6Set = (function() {
-	if ( typeof Set !== 'function' ) {
+	if ( typeof Set !== "function" ) {
 		return false;
 	}
 
 	var s = new Set();
-	return ( QUnit.objectType( s ) === 'set' );
+	return ( QUnit.objectType( s ) === "set" );
 })();
 
-//  - in IE 11, QUnit.objectType( new Map() ) === 'object'
+// - in IE 11, QUnit.objectType( new Map() ) === "object"
 var hasES6Map = (function() {
-	if ( typeof Map !== 'function' ) {
+	if ( typeof Map !== "function" ) {
 		return false;
 	}
 
 	var m = new Map();
-	return ( QUnit.objectType( m ) === 'map' );
+	return ( QUnit.objectType( m ) === "map" );
 })();
 
 QUnit[ hasES6Set ? "test" : "skip" ]( "Sets", function ( assert ) {

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1677,8 +1677,8 @@ QUnit[ hasES6Map ? "test" : "skip" ]("Maps", function ( assert ) {
 
 	// Same keys, different values
 	m1 = new Map([
-		[ 1, 'one' ],
-		[ 2, 'two' ]
+		[ 1, "one" ],
+		[ 2, "two" ]
 	]);
 	m2 = new Map([
 		[ 1, 1],

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1528,3 +1528,226 @@ QUnit.test( "Test that must be done at the end because they extend some primitiv
 		);
 	}
 );
+
+QUnit.module( "equiv Maps and Sets");
+// Note: we cannot do simple check for constructor existence,
+// as IE 11 implementation of Sets/Maps is incomplete.
+//  - in IE 11, Sets/Maps do not support constructors, e.g. new Set( [1] ) fails.
+//  - in IE 11, QUnit.objectType( new Set() ) === 'object'
+//
+// This is a more robust way of checking for ES6 Set/Map support.
+var hasES6Set = (function() {
+	try {
+		var s = new Set([ 1, 2, 3 ]);
+		if (s.size !== 3 || !s.has(2)) {
+			return false;
+		}
+	}
+	catch (e) {
+		return false;
+	}
+
+	return true;
+})();
+
+var hasES6Map = (function() {
+	try {
+		var m = new Map([
+			[ 1, 2],
+			[ 3, 4]
+		]);
+		if (m.size !== 2 || !m.has(1)) {
+			return false;
+		}
+	}
+	catch (e) {
+		return false;
+	}
+
+	return true;
+})();
+
+QUnit[ hasES6Set ? "test" : "skip" ]('Sets', function ( assert ) {
+	var s1, s2, s3, s4, o1, o2, o3, m1, m2, m3;
+
+	// Empty sets
+	s1 = new Set();
+	s2 = new Set();
+	assert.equal( QUnit.equiv( s1, s2 ), true, 'Empty Sets');
+	s1 = new Set([]);
+	s2 = new Set([]);
+	assert.equal( QUnit.equiv( s1, s2 ), true, 'Empty sets init with empty arrays');
+
+	// Simple cases
+	s1 = new Set( [1] );
+	s2 = new Set( [1] );
+	s3 = new Set( [3] );
+	assert.equal( QUnit.equiv( s1, s2 ), true, 'Single element sets [1] vs [1]');
+	assert.equal( QUnit.equiv( s1, s3 ), false, 'Single element sets [1] vs [3]');
+
+	// Tricky values
+	s1 = new Set();
+	s1.add( undefined );
+	s1.add( null );
+	s1.add( false );
+	s1.add( 0 );
+	s1.add( NaN );
+	s1.add( Infinity );
+	s1.add( -Infinity );
+	s2 = new Set([ undefined, null, false, 0, NaN, Infinity, -Infinity ]);
+	assert.equal( QUnit.equiv( s1, s2 ), true, 'Mutiple-element sets of tricky values');
+
+	// Sets Containing objects
+	o1 = {'foo': 0, 'bar': true};
+	o2 = {'foo': 0, 'bar': true};
+	o3 = {'foo': 1, 'bar': true};
+	s1 = new Set([ o1, o3 ]);
+	s2 = new Set([ o1, o3 ]);
+	assert.equal( QUnit.equiv( s1, s2 ), true, 'Sets containing same objects');
+	s1 = new Set([ o1 ]);
+	s2 = new Set([ o2 ]);
+	assert.equal( QUnit.equiv( s1, s2 ), true, 'Sets containing deeply-equal objects');
+	s1 = new Set([ o1 ]);
+	s2 = new Set([ o3 ]);
+	assert.equal( QUnit.equiv( s1, s2 ), false, 'Sets containing different objects');
+
+	// Sets containing sets
+	s1 = new Set([ 1, 2, 3 ]);
+	s2 = new Set([ 1, 2, 3 ]);
+	s3 = new Set([ s1 ]);
+	s4 = new Set([ s2 ]);
+	assert.equal( QUnit.equiv( s3, s4 ), true, 'Sets containing deeply-equal sets');
+	
+	// Sets containing different sets
+	s1 = new Set([ 1, 2, 3 ]);
+	s2 = new Set([ 1, 2, 3, 4 ]);
+	s3 = new Set([ s1 ]);
+	s4 = new Set([ s2 ]);
+	assert.equal( QUnit.equiv( s3, s4 ), false, 'Sets containing different sets');
+	
+	// Sets containing maps
+	m1 = new Map([ [ 1,1 ] ]);
+	m2 = new Map([ [ 1,1 ] ]);
+	m3 = new Map([ [ 1,3 ] ]);
+	s3 = new Set([ m1 ]);
+	s4 = new Set([ m2 ]);
+	assert.equal( QUnit.equiv( s3, s4 ), true, 'Sets containing different but deeply-equal maps');
+	s3 = new Set([ m1 ]);
+	s4 = new Set([ m3 ]);
+	assert.equal( QUnit.equiv( s3, s4 ), false, 'Sets containing different maps');
+});
+
+QUnit[ hasES6Map ? "test" : "skip" ]('Maps', function ( assert ) {
+	var m1, m2, m3, m4, o1, o2, o3, s1, s2, s3;
+
+	// Empty maps
+	m1 = new Map();
+	m2 = new Map();
+	assert.equal( QUnit.equiv(m1, m2), true, 'Empty maps');
+	m1 = new Map([]);
+	m2 = new Map([]);
+	assert.equal( QUnit.equiv(m1, m2), true, 'Empty maps init with empty arrays');
+
+	// Simple cases
+	m1 = new Map([ [ 1,1 ] ]);
+	m2 = new Map([ [ 1,1 ] ]);
+	m3 = new Map([ [ 1,3 ] ]);
+	assert.equal( QUnit.equiv( m1, m2 ), true, 'Single element maps [1,1] vs [1,1]');
+	assert.equal( QUnit.equiv( m1, m3 ), false, 'Single element maps [1,1] vs [1,3]');
+
+	// Tricky values
+	m1 = new Map();
+	m1.set( undefined, undefined );
+	m1.set( null, null );
+	m1.set( false, false );
+	m1.set( 0, 0 );
+	m1.set( NaN, NaN );
+	m1.set( Infinity, Infinity );
+	m1.set( -Infinity, -Infinity );
+	m2 = new Map([
+		[ undefined, undefined ],
+		[ null, null ],
+		[ false, false ],
+		[ 0, 0 ],
+		[ NaN, NaN ],
+		[ Infinity, Infinity ],
+		[ -Infinity, -Infinity ]
+	]);
+	assert.equal( QUnit.equiv( m1, m2 ), true, 'Mutiple-element maps of tricky values');
+
+	// Same keys, different values
+	m1 = new Map([
+		[ 1, 'one' ],
+		[ 2, 'two' ]
+	]);
+	m2 = new Map([
+		[ 1, 1],
+		[ 2, 2]
+	]);
+	assert.equal( QUnit.equiv( m1, m2 ), false, 'Same key, different values');
+
+	// Maps Containing objects
+	o1 = {'foo':0, 'bar':true};
+	o2 = {'foo':0, 'bar':true};
+	o3 = {'foo':1, 'bar':true};
+	m1 = new Map([
+		[ 1, o1 ],
+		[ 2, o3 ]
+	]);
+	m2 = new Map([
+		[ 1, o1 ],
+		[ 2, o3 ]
+	]);
+	assert.equal( QUnit.equiv( m1, m2 ), true, 'Maps containing same objects');
+	m1 = new Map([
+		[ 1, o1]
+	]);
+	m2 = new Map([
+		[ 1, o2]
+	]);
+	assert.equal( QUnit.equiv( m1, m2 ), true, 'Maps containing diffrent but deeply-equal objects');
+
+	// Maps containing different objects
+	m1 = new Map([
+		[ 1, o1 ]
+	]);
+	m2 = new Map([
+		[ 1, o3 ]
+	]);
+	assert.equal( QUnit.equiv( m1, m2), false, 'Maps containing different objects');
+
+	// Maps containing maps
+	m1 = new Map([ [ 1,1 ] ]);
+	m2 = new Map([ [ 1,1 ] ]);
+	m3 = new Map([ [ 'myMap', m1] ]);
+	m4 = new Map([ [ 'myMap', m2] ]);
+	assert.equal( QUnit.equiv( m3, m4 ), true, 'Maps containing deeply-equal maps');
+
+	// Maps containing different maps
+	m1 = new Map([ [ 1,1 ] ]);
+	m2 = new Map([ [ 1,2 ] ]);
+	m3 = new Map([ [ 'myMap', m1] ]);
+	m4 = new Map([ [ 'myMap', m2] ]);
+	assert.equal( QUnit.equiv( m3, m4 ), false, 'Maps containing different maps');
+
+	// Maps containing sets
+	s1 = new Set([ 1, 2, 3 ]);
+	s2 = new Set([ 1, 2, 3 ]);
+	s3 = new Set([ 1, 2, 3, 4 ]);
+	m1 = new Map([
+		[1, s1]
+	]);
+	m2 = new Map([
+		[1, s2]
+	]);
+	assert.equal( QUnit.equiv( m1, m2 ), true, 'Maps containing diffrent but deeply-equal sets');
+	
+	// Maps containing different sets
+	m1 = new Map([
+		[1, s1]
+	]);
+	m2 = new Map([
+		[1, s3]
+	]);
+	assert.equal( QUnit.equiv( m1, m2 ), false, 'Maps containing diffrent sets');
+});

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1567,16 +1567,13 @@ var hasES6Map = (function() {
 	return true;
 })();
 
-QUnit[ hasES6Set ? "test" : "skip" ]("Sets", function ( assert ) {
+QUnit[ hasES6Set ? "test" : "skip" ]( "Sets", function ( assert ) {
 	var s1, s2, s3, s4, o1, o2, o3, m1, m2, m3;
 
 	// Empty sets
 	s1 = new Set();
-	s2 = new Set();
-	assert.equal( QUnit.equiv( s1, s2 ), true, "Empty Sets");
-	s1 = new Set([]);
 	s2 = new Set([]);
-	assert.equal( QUnit.equiv( s1, s2 ), true, "Empty sets init with empty arrays");
+	assert.equal( QUnit.equiv( s1, s2 ), true, "Empty sets");
 
 	// Simple cases
 	s1 = new Set( [1] );
@@ -1586,14 +1583,7 @@ QUnit[ hasES6Set ? "test" : "skip" ]("Sets", function ( assert ) {
 	assert.equal( QUnit.equiv( s1, s3 ), false, "Single element sets [1] vs [3]");
 
 	// Tricky values
-	s1 = new Set();
-	s1.add( undefined );
-	s1.add( null );
-	s1.add( false );
-	s1.add( 0 );
-	s1.add( NaN );
-	s1.add( Infinity );
-	s1.add( -Infinity );
+	s1 = new Set([ undefined, null, false, 0, NaN, Infinity, -Infinity ]);
 	s2 = new Set([ undefined, null, false, 0, NaN, Infinity, -Infinity ]);
 	assert.equal( QUnit.equiv( s1, s2 ), true, "Mutiple-element sets of tricky values");
 
@@ -1637,16 +1627,13 @@ QUnit[ hasES6Set ? "test" : "skip" ]("Sets", function ( assert ) {
 	assert.equal( QUnit.equiv( s3, s4 ), false, "Sets containing different maps");
 });
 
-QUnit[ hasES6Map ? "test" : "skip" ]("Maps", function ( assert ) {
+QUnit[ hasES6Map ? "test" : "skip" ]( "Maps", function ( assert ) {
 	var m1, m2, m3, m4, o1, o2, o3, s1, s2, s3;
 
 	// Empty maps
 	m1 = new Map();
-	m2 = new Map();
-	assert.equal( QUnit.equiv(m1, m2), true, "Empty maps");
-	m1 = new Map([]);
 	m2 = new Map([]);
-	assert.equal( QUnit.equiv(m1, m2), true, "Empty maps init with empty arrays");
+	assert.equal( QUnit.equiv( m1, m2 ), true, "Empty maps");
 
 	// Simple cases
 	m1 = new Map([ [ 1,1 ] ]);
@@ -1656,14 +1643,15 @@ QUnit[ hasES6Map ? "test" : "skip" ]("Maps", function ( assert ) {
 	assert.equal( QUnit.equiv( m1, m3 ), false, "Single element maps [1,1] vs [1,3]");
 
 	// Tricky values
-	m1 = new Map();
-	m1.set( undefined, undefined );
-	m1.set( null, null );
-	m1.set( false, false );
-	m1.set( 0, 0 );
-	m1.set( NaN, NaN );
-	m1.set( Infinity, Infinity );
-	m1.set( -Infinity, -Infinity );
+	m1 =  new Map([
+		[ undefined, undefined ],
+		[ null, null ],
+		[ false, false ],
+		[ 0, 0 ],
+		[ NaN, NaN ],
+		[ Infinity, Infinity ],
+		[ -Infinity, -Infinity ]
+	]);
 	m2 = new Map([
 		[ undefined, undefined ],
 		[ null, null ],
@@ -1681,10 +1669,10 @@ QUnit[ hasES6Map ? "test" : "skip" ]("Maps", function ( assert ) {
 		[ 2, "two" ]
 	]);
 	m2 = new Map([
-		[ 1, 1],
-		[ 2, 2]
+		[ 1, 1 ],
+		[ 2, 2 ]
 	]);
-	assert.equal( QUnit.equiv( m1, m2 ), false, "Same key, different values");
+	assert.equal( QUnit.equiv( m1, m2 ), false, "Maps with same keys, different values");
 
 	// Maps Containing objects
 	o1 = {"foo":0, "bar":true};
@@ -1700,10 +1688,10 @@ QUnit[ hasES6Map ? "test" : "skip" ]("Maps", function ( assert ) {
 	]);
 	assert.equal( QUnit.equiv( m1, m2 ), true, "Maps containing same objects");
 	m1 = new Map([
-		[ 1, o1]
+		[ 1, o1 ]
 	]);
 	m2 = new Map([
-		[ 1, o2]
+		[ 1, o2 ]
 	]);
 	assert.equal( QUnit.equiv( m1, m2 ), true, "Maps containing diffrent but deeply-equal objects");
 
@@ -1719,15 +1707,15 @@ QUnit[ hasES6Map ? "test" : "skip" ]("Maps", function ( assert ) {
 	// Maps containing maps
 	m1 = new Map([ [ 1,1 ] ]);
 	m2 = new Map([ [ 1,1 ] ]);
-	m3 = new Map([ [ "myMap", m1] ]);
-	m4 = new Map([ [ "myMap", m2] ]);
+	m3 = new Map([ [ "myMap", m1 ] ]);
+	m4 = new Map([ [ "myMap", m2 ] ]);
 	assert.equal( QUnit.equiv( m3, m4 ), true, "Maps containing deeply-equal maps");
 
 	// Maps containing different maps
 	m1 = new Map([ [ 1,1 ] ]);
 	m2 = new Map([ [ 1,2 ] ]);
-	m3 = new Map([ [ "myMap", m1] ]);
-	m4 = new Map([ [ "myMap", m2] ]);
+	m3 = new Map([ [ "myMap", m1 ] ]);
+	m4 = new Map([ [ "myMap", m2 ] ]);
 	assert.equal( QUnit.equiv( m3, m4 ), false, "Maps containing different maps");
 
 	// Maps containing sets
@@ -1735,10 +1723,10 @@ QUnit[ hasES6Map ? "test" : "skip" ]("Maps", function ( assert ) {
 	s2 = new Set([ 1, 2, 3 ]);
 	s3 = new Set([ 1, 2, 3, 4 ]);
 	m1 = new Map([
-		[1, s1]
+		[ 1, s1 ]
 	]);
 	m2 = new Map([
-		[1, s2]
+		[ 1, s2 ]
 	]);
 	assert.equal( QUnit.equiv( m1, m2 ), true, "Maps containing diffrent but deeply-equal sets");
 	

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1567,23 +1567,23 @@ var hasES6Map = (function() {
 	return true;
 })();
 
-QUnit[ hasES6Set ? "test" : "skip" ]('Sets', function ( assert ) {
+QUnit[ hasES6Set ? "test" : "skip" ]("Sets", function ( assert ) {
 	var s1, s2, s3, s4, o1, o2, o3, m1, m2, m3;
 
 	// Empty sets
 	s1 = new Set();
 	s2 = new Set();
-	assert.equal( QUnit.equiv( s1, s2 ), true, 'Empty Sets');
+	assert.equal( QUnit.equiv( s1, s2 ), true, "Empty Sets");
 	s1 = new Set([]);
 	s2 = new Set([]);
-	assert.equal( QUnit.equiv( s1, s2 ), true, 'Empty sets init with empty arrays');
+	assert.equal( QUnit.equiv( s1, s2 ), true, "Empty sets init with empty arrays");
 
 	// Simple cases
 	s1 = new Set( [1] );
 	s2 = new Set( [1] );
 	s3 = new Set( [3] );
-	assert.equal( QUnit.equiv( s1, s2 ), true, 'Single element sets [1] vs [1]');
-	assert.equal( QUnit.equiv( s1, s3 ), false, 'Single element sets [1] vs [3]');
+	assert.equal( QUnit.equiv( s1, s2 ), true, "Single element sets [1] vs [1]");
+	assert.equal( QUnit.equiv( s1, s3 ), false, "Single element sets [1] vs [3]");
 
 	// Tricky values
 	s1 = new Set();
@@ -1595,35 +1595,35 @@ QUnit[ hasES6Set ? "test" : "skip" ]('Sets', function ( assert ) {
 	s1.add( Infinity );
 	s1.add( -Infinity );
 	s2 = new Set([ undefined, null, false, 0, NaN, Infinity, -Infinity ]);
-	assert.equal( QUnit.equiv( s1, s2 ), true, 'Mutiple-element sets of tricky values');
+	assert.equal( QUnit.equiv( s1, s2 ), true, "Mutiple-element sets of tricky values");
 
 	// Sets Containing objects
-	o1 = {'foo': 0, 'bar': true};
-	o2 = {'foo': 0, 'bar': true};
-	o3 = {'foo': 1, 'bar': true};
+	o1 = {"foo": 0, "bar": true};
+	o2 = {"foo": 0, "bar": true};
+	o3 = {"foo": 1, "bar": true};
 	s1 = new Set([ o1, o3 ]);
 	s2 = new Set([ o1, o3 ]);
-	assert.equal( QUnit.equiv( s1, s2 ), true, 'Sets containing same objects');
+	assert.equal( QUnit.equiv( s1, s2 ), true, "Sets containing same objects");
 	s1 = new Set([ o1 ]);
 	s2 = new Set([ o2 ]);
-	assert.equal( QUnit.equiv( s1, s2 ), true, 'Sets containing deeply-equal objects');
+	assert.equal( QUnit.equiv( s1, s2 ), true, "Sets containing deeply-equal objects");
 	s1 = new Set([ o1 ]);
 	s2 = new Set([ o3 ]);
-	assert.equal( QUnit.equiv( s1, s2 ), false, 'Sets containing different objects');
+	assert.equal( QUnit.equiv( s1, s2 ), false, "Sets containing different objects");
 
 	// Sets containing sets
 	s1 = new Set([ 1, 2, 3 ]);
 	s2 = new Set([ 1, 2, 3 ]);
 	s3 = new Set([ s1 ]);
 	s4 = new Set([ s2 ]);
-	assert.equal( QUnit.equiv( s3, s4 ), true, 'Sets containing deeply-equal sets');
+	assert.equal( QUnit.equiv( s3, s4 ), true, "Sets containing deeply-equal sets");
 	
 	// Sets containing different sets
 	s1 = new Set([ 1, 2, 3 ]);
 	s2 = new Set([ 1, 2, 3, 4 ]);
 	s3 = new Set([ s1 ]);
 	s4 = new Set([ s2 ]);
-	assert.equal( QUnit.equiv( s3, s4 ), false, 'Sets containing different sets');
+	assert.equal( QUnit.equiv( s3, s4 ), false, "Sets containing different sets");
 	
 	// Sets containing maps
 	m1 = new Map([ [ 1,1 ] ]);
@@ -1631,29 +1631,29 @@ QUnit[ hasES6Set ? "test" : "skip" ]('Sets', function ( assert ) {
 	m3 = new Map([ [ 1,3 ] ]);
 	s3 = new Set([ m1 ]);
 	s4 = new Set([ m2 ]);
-	assert.equal( QUnit.equiv( s3, s4 ), true, 'Sets containing different but deeply-equal maps');
+	assert.equal( QUnit.equiv( s3, s4 ), true, "Sets containing different but deeply-equal maps");
 	s3 = new Set([ m1 ]);
 	s4 = new Set([ m3 ]);
-	assert.equal( QUnit.equiv( s3, s4 ), false, 'Sets containing different maps');
+	assert.equal( QUnit.equiv( s3, s4 ), false, "Sets containing different maps");
 });
 
-QUnit[ hasES6Map ? "test" : "skip" ]('Maps', function ( assert ) {
+QUnit[ hasES6Map ? "test" : "skip" ]("Maps", function ( assert ) {
 	var m1, m2, m3, m4, o1, o2, o3, s1, s2, s3;
 
 	// Empty maps
 	m1 = new Map();
 	m2 = new Map();
-	assert.equal( QUnit.equiv(m1, m2), true, 'Empty maps');
+	assert.equal( QUnit.equiv(m1, m2), true, "Empty maps");
 	m1 = new Map([]);
 	m2 = new Map([]);
-	assert.equal( QUnit.equiv(m1, m2), true, 'Empty maps init with empty arrays');
+	assert.equal( QUnit.equiv(m1, m2), true, "Empty maps init with empty arrays");
 
 	// Simple cases
 	m1 = new Map([ [ 1,1 ] ]);
 	m2 = new Map([ [ 1,1 ] ]);
 	m3 = new Map([ [ 1,3 ] ]);
-	assert.equal( QUnit.equiv( m1, m2 ), true, 'Single element maps [1,1] vs [1,1]');
-	assert.equal( QUnit.equiv( m1, m3 ), false, 'Single element maps [1,1] vs [1,3]');
+	assert.equal( QUnit.equiv( m1, m2 ), true, "Single element maps [1,1] vs [1,1]");
+	assert.equal( QUnit.equiv( m1, m3 ), false, "Single element maps [1,1] vs [1,3]");
 
 	// Tricky values
 	m1 = new Map();
@@ -1673,7 +1673,7 @@ QUnit[ hasES6Map ? "test" : "skip" ]('Maps', function ( assert ) {
 		[ Infinity, Infinity ],
 		[ -Infinity, -Infinity ]
 	]);
-	assert.equal( QUnit.equiv( m1, m2 ), true, 'Mutiple-element maps of tricky values');
+	assert.equal( QUnit.equiv( m1, m2 ), true, "Mutiple-element maps of tricky values");
 
 	// Same keys, different values
 	m1 = new Map([
@@ -1684,12 +1684,12 @@ QUnit[ hasES6Map ? "test" : "skip" ]('Maps', function ( assert ) {
 		[ 1, 1],
 		[ 2, 2]
 	]);
-	assert.equal( QUnit.equiv( m1, m2 ), false, 'Same key, different values');
+	assert.equal( QUnit.equiv( m1, m2 ), false, "Same key, different values");
 
 	// Maps Containing objects
-	o1 = {'foo':0, 'bar':true};
-	o2 = {'foo':0, 'bar':true};
-	o3 = {'foo':1, 'bar':true};
+	o1 = {"foo":0, "bar":true};
+	o2 = {"foo":0, "bar":true};
+	o3 = {"foo":1, "bar":true};
 	m1 = new Map([
 		[ 1, o1 ],
 		[ 2, o3 ]
@@ -1698,14 +1698,14 @@ QUnit[ hasES6Map ? "test" : "skip" ]('Maps', function ( assert ) {
 		[ 1, o1 ],
 		[ 2, o3 ]
 	]);
-	assert.equal( QUnit.equiv( m1, m2 ), true, 'Maps containing same objects');
+	assert.equal( QUnit.equiv( m1, m2 ), true, "Maps containing same objects");
 	m1 = new Map([
 		[ 1, o1]
 	]);
 	m2 = new Map([
 		[ 1, o2]
 	]);
-	assert.equal( QUnit.equiv( m1, m2 ), true, 'Maps containing diffrent but deeply-equal objects');
+	assert.equal( QUnit.equiv( m1, m2 ), true, "Maps containing diffrent but deeply-equal objects");
 
 	// Maps containing different objects
 	m1 = new Map([
@@ -1714,21 +1714,21 @@ QUnit[ hasES6Map ? "test" : "skip" ]('Maps', function ( assert ) {
 	m2 = new Map([
 		[ 1, o3 ]
 	]);
-	assert.equal( QUnit.equiv( m1, m2), false, 'Maps containing different objects');
+	assert.equal( QUnit.equiv( m1, m2), false, "Maps containing different objects");
 
 	// Maps containing maps
 	m1 = new Map([ [ 1,1 ] ]);
 	m2 = new Map([ [ 1,1 ] ]);
-	m3 = new Map([ [ 'myMap', m1] ]);
-	m4 = new Map([ [ 'myMap', m2] ]);
-	assert.equal( QUnit.equiv( m3, m4 ), true, 'Maps containing deeply-equal maps');
+	m3 = new Map([ [ "myMap", m1] ]);
+	m4 = new Map([ [ "myMap", m2] ]);
+	assert.equal( QUnit.equiv( m3, m4 ), true, "Maps containing deeply-equal maps");
 
 	// Maps containing different maps
 	m1 = new Map([ [ 1,1 ] ]);
 	m2 = new Map([ [ 1,2 ] ]);
-	m3 = new Map([ [ 'myMap', m1] ]);
-	m4 = new Map([ [ 'myMap', m2] ]);
-	assert.equal( QUnit.equiv( m3, m4 ), false, 'Maps containing different maps');
+	m3 = new Map([ [ "myMap", m1] ]);
+	m4 = new Map([ [ "myMap", m2] ]);
+	assert.equal( QUnit.equiv( m3, m4 ), false, "Maps containing different maps");
 
 	// Maps containing sets
 	s1 = new Set([ 1, 2, 3 ]);
@@ -1740,7 +1740,7 @@ QUnit[ hasES6Map ? "test" : "skip" ]('Maps', function ( assert ) {
 	m2 = new Map([
 		[1, s2]
 	]);
-	assert.equal( QUnit.equiv( m1, m2 ), true, 'Maps containing diffrent but deeply-equal sets');
+	assert.equal( QUnit.equiv( m1, m2 ), true, "Maps containing diffrent but deeply-equal sets");
 	
 	// Maps containing different sets
 	m1 = new Map([
@@ -1749,5 +1749,5 @@ QUnit[ hasES6Map ? "test" : "skip" ]('Maps', function ( assert ) {
 	m2 = new Map([
 		[1, s3]
 	]);
-	assert.equal( QUnit.equiv( m1, m2 ), false, 'Maps containing diffrent sets');
+	assert.equal( QUnit.equiv( m1, m2 ), false, "Maps containing diffrent sets");
 });

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1530,41 +1530,25 @@ QUnit.test( "Test that must be done at the end because they extend some primitiv
 );
 
 QUnit.module( "equiv Maps and Sets");
-// Note: we cannot do simple check for constructor existence,
-// as IE 11 implementation of Sets/Maps is incomplete.
-//  - in IE 11, Sets/Maps do not support constructors, e.g. new Set( [1] ) fails.
+
 //  - in IE 11, QUnit.objectType( new Set() ) === 'object'
-//
-// This is a more robust way of checking for ES6 Set/Map support.
 var hasES6Set = (function() {
-	try {
-		var s = new Set([ 1, 2, 3 ]);
-		if (s.size !== 3 || !s.has(2)) {
-			return false;
-		}
-	}
-	catch (e) {
+	if ( typeof Set !== 'function' ) {
 		return false;
 	}
 
-	return true;
+	var s = new Set();
+	return ( QUnit.objectType( s ) === 'set' );
 })();
 
+//  - in IE 11, QUnit.objectType( new Map() ) === 'object'
 var hasES6Map = (function() {
-	try {
-		var m = new Map([
-			[ 1, 2],
-			[ 3, 4]
-		]);
-		if (m.size !== 2 || !m.has(1)) {
-			return false;
-		}
-	}
-	catch (e) {
+	if ( typeof Map !== 'function' ) {
 		return false;
 	}
 
-	return true;
+	var m = new Map();
+	return ( QUnit.objectType( m ) === 'map' );
 })();
 
 QUnit[ hasES6Set ? "test" : "skip" ]( "Sets", function ( assert ) {


### PR DESCRIPTION
The main idea is to reduce ES6 Set and Map comparisons into Array comparisons.

Ref: https://github.com/jquery/qunit/issues/833