### PR TITLE
Build: Update the license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,7 @@
   "bugs": {
     "url": "https://github.com/jquery/qunit/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/jquery/qunit/blob/master/LICENSE.txt"
-    }
-  ],
+  "license": "MIT",
   "files": [
     "qunit/qunit.js",
     "qunit/qunit.css",


### PR DESCRIPTION
Same as https://github.com/jquery/jquery/pull/2330#issue-78041000:

> specifying the type and URL is deprecated:
> 
> https://docs.npmjs.com/files/package.json#license
> http://npm1k.org/