### PR TITLE
Fix bug while no document(nodejs, react-native)

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -392,12 +392,13 @@ function toolbarModuleFilterHtml() {
 
 function toolbarModuleFilter() {
 	var toolbar = id( "qunit-testrunner-toolbar" ),
-		moduleFilter = document.createElement( "span" ),
 		moduleFilterHtml = toolbarModuleFilterHtml();
 
 	if ( !toolbar || !moduleFilterHtml ) {
 		return false;
 	}
+	
+	var moduleFilter = document.createElement( "span" );
 
 	moduleFilter.setAttribute( "id", "qunit-modulefilter-container" );
 	moduleFilter.innerHTML = moduleFilterHtml;


### PR DESCRIPTION
document.createElement('span') will throw an error while in nodejs or react-native.

so I move that line of code to the below.