### PR TITLE
Readme: Replace Jenkins badge with Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](http://jenkins.jquery.com/job/QUnit/badge/icon)](http://jenkins.jquery.com/job/QUnit/)
-[![Coverage Status](https://coveralls.io/repos/jquery/qunit/badge.png)](https://coveralls.io/r/jquery/qunit)
+[![Build Status](https://travis-ci.org/jquery/qunit.svg?branch=master)](https://travis-ci.org/jquery/qunit) [![Coverage Status](https://coveralls.io/repos/jquery/qunit/badge.svg)](https://coveralls.io/github/jquery/qunit)
 
 # [QUnit](http://qunitjs.com) - A JavaScript Unit Testing Framework.
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
       "Core",
       "Dump",
       "HTML Reporter",
+      "Readme",
       "Test",
       "Tests"
     ]


### PR DESCRIPTION
Replace badge from jenkins.jquery.org with badge from Travis CI

Follows-up d1564e1a47 and pull #849, which remove TestSwarm from the Jenkins run.
However that means the primary badge isn't very useful anymore and doesn't
include cross-browser results. It also seems that the Jenkins badge plugin doesn't
handle proxy caching properly, causing it to show as "Unstable" on GitHub long
after the build was fixed.

Update both badges to use SVG so that it doesn't look pixelated on high density screens.