### PR TITLE
Fix typo enviroment->environment

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -171,7 +171,7 @@ QUnit.assert = Assert.prototype = {
 	}
 };
 
-// Provide an alternative to assert.throws(), for enviroments that consider throws a reserved word
+// Provide an alternative to assert.throws(), for environments that consider throws a reserved word
 // Known to us are: Closure Compiler, Narwhal
 (function() {
 	/*jshint sub:true */


### PR DESCRIPTION
I found a small misspelling in comment.
How about this?