### PR TITLE
Test: Allow async test defined from test callback parameters

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -89,7 +89,7 @@ Test.prototype = {
 	},
 
 	run: function() {
-		var promise;
+		var promise, done;
 
 		config.current = this;
 
@@ -97,16 +97,20 @@ Test.prototype = {
 			QUnit.stop();
 		}
 
+		if ( this.callback.length > 1 ) {
+			done = this.assert.async.call( this.assert );
+		}
+
 		this.callbackStarted = now();
 
 		if ( config.notrycatch ) {
-			promise = this.callback.call( this.testEnvironment, this.assert );
+			promise = this.callback.call( this.testEnvironment, this.assert, done );
 			this.resolvePromise( promise );
 			return;
 		}
 
 		try {
-			promise = this.callback.call( this.testEnvironment, this.assert );
+			promise = this.callback.call( this.testEnvironment, this.assert, done );
 			this.resolvePromise( promise );
 		} catch ( e ) {
 			this.pushFailure( "Died on test #" + ( this.assertions.length + 1 ) + " " +

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -169,6 +169,15 @@ QUnit.test( "fails if callback is called more than once in test", function( asse
 	done();
 });
 
+QUnit.module( "async test defined by test callback" );
+
+QUnit.test( "defined done", function( assert, done ) {
+	setTimeout(function() {
+		assert.ok( true );
+		done();
+	});
+});
+
 QUnit.module( "assert.async fails if callback is called more than once in", {
 	beforeEach: function( assert ) {
 


### PR DESCRIPTION
As requested on twitter by @fnando, this proposal brings a shortcut to define async tests through the test callback parameters.

This is based on the test callback function length and it is worth to investigate if it doesn't conflict anything on extensions like ember-qunit.