### PR TITLE
Core: Support Symbol types on QUnit.equiv

### DIFF
--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -99,6 +99,7 @@ function objectType( obj ) {
 		case "Date":
 		case "RegExp":
 		case "Function":
+		case "Symbol":
 			return type.toLowerCase();
 	}
 	if ( typeof obj === "object" ) {

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -83,7 +83,7 @@ function objectType( obj ) {
 	}
 
 	var match = toString.call( obj ).match( /^\[object\s(.*)\]$/ ),
-		type = match && match[ 1 ] || "";
+		type = match && match[ 1 ];
 
 	switch ( type ) {
 		case "Number":
@@ -104,7 +104,6 @@ function objectType( obj ) {
 	if ( typeof obj === "object" ) {
 		return "object";
 	}
-	return undefined;
 }
 
 // Safe object type checking

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -236,16 +236,9 @@ QUnit.equiv = (function() {
 		}
 	};
 
-	// Call the o related callback with the given arguments.
-	function bindCallbacks( o, callbacks, args ) {
-		var prop = QUnit.objectType( o );
-		if ( prop ) {
-			if ( QUnit.objectType( callbacks[ prop ] ) === "function" ) {
-				return callbacks[ prop ].apply( callbacks, args );
-			} else {
-				return callbacks[ prop ]; // or undefined
-			}
-		}
+	function typeEquiv( a, b ) {
+		var prop = QUnit.objectType( a );
+		return callbacks[ prop ]( b, a );
 	}
 
 	// The real equiv function
@@ -269,7 +262,7 @@ QUnit.equiv = (function() {
 				// Don't lose time with error prone cases
 				return false;
 			} else {
-				return bindCallbacks( a, callbacks, [ b, a ] );
+				return typeEquiv( a, b );
 			}
 
 		// Apply transition with (1..n) arguments

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -63,6 +63,7 @@ QUnit.equiv = (function() {
 		"number": useStrictEquality,
 		"null": useStrictEquality,
 		"undefined": useStrictEquality,
+		"symbol": useStrictEquality,
 
 		"nan": function( b ) {
 			return isNaN( b );

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1,4 +1,4 @@
-/* globals Set:false, Map:false */
+/* globals Set:false, Map:false, Symbol:false */
 
 QUnit.module( "equiv" );
 
@@ -1779,3 +1779,20 @@ QUnit[ hasES6Map ? "test" : "skip" ]( "Maps", function ( assert ) {
 	m2 = new Map( [	[ 1, s3 ] ] );
 	assert.equal( QUnit.equiv( m1, m2 ), false, "Maps containing diffrent sets" );
 });
+
+QUnit.module( "equiv Symbols" );
+
+var hasES6Symbol = ( function() {
+	return typeof Symbol === "function";
+} )();
+
+QUnit[ hasES6Symbol ? "test" : "skip" ]( "regular checks", function ( assert ) {
+	var a = Symbol( 1 );
+	var b = Symbol( 1 );
+
+	assert.equal( QUnit.equiv( a, a ), true, "Same symbol is equivalent" );
+	assert.equal(
+		QUnit.equiv( a, b ), false,
+		"Not equivalent to another similar symbol built build on the same token"
+	);
+} );


### PR DESCRIPTION
Also adds an extra code golf (with step-by-step commits) based on coverage.

As mentioned on 5e4ba82, `QUnit.objectType` already covers all JS types except the new comming Symbol on ES2015. For other object types it will return `'object'` which is covered too.

