### PR TITLE
Core: Issue 846 semaphore NaN

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -111,6 +111,17 @@ extend( QUnit, {
 			// If a test is running, adjust its semaphore
 			config.current.semaphore -= count || 1;
 
+			//If semaphore is non-numeric, throw error
+			if ( isNaN( config.current.semaphore ) ) {
+				config.current.semaphore = 0;
+
+				QUnit.pushFailure(
+					"Called start() with a NaN value",
+					sourceFromStacktrace( 2 )
+				);
+				return;
+			}
+
 			// Don't start until equal number of stop-calls
 			if ( config.current.semaphore > 0 ) {
 				return;


### PR DESCRIPTION
Fix for `config.current.semaphore` being set to `NaN` if truthy and non-numeric.  Still need to write
tests.

Closes #846