### PR TITLE
Test: Deprecate the 'expected' argument of QUnit.test

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -574,7 +574,9 @@ QUnit.done(function( details ) {
 			details.total,
 			"</span> passed, <span class='failed'>",
 			details.failed,
-			"</span> failed."
+			"</span> failed.",
+			QUnit.warnings.length,
+			" warnings"
 		].join( "" );
 
 	if ( banner ) {
@@ -665,6 +667,9 @@ QUnit.log(function( details ) {
 
 	message = escapeText( details.message ) || ( details.result ? "okay" : "failed" );
 	message = "<span class='test-message'>" + message + "</span>";
+	if ( details.warnings !== undefined ) {
+		message += "<span class='test-warning'>" + details.warnings + "</span>";
+	}
 	message += "<span class='runtime'>@ " + details.runtime + " ms</span>";
 
 	// pushFailure doesn't provide details.expected

--- a/src/core.js
+++ b/src/core.js
@@ -6,6 +6,8 @@ QUnit.isLocal = !( defined.document && window.location.protocol !== "file:" );
 // Expose the current QUnit version
 QUnit.version = "@VERSION";
 
+QUnit.warnings = [];
+
 extend( QUnit, {
 
 	// call on start of module test to prepend name to all tests

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -136,3 +136,12 @@ var getUrlParams = function() {
 
 	return urlParams;
 };
+
+function deprecateWarns( message ) {
+	var console = global.console;
+	message = "DEPRECATED: " + message;
+	if ( console && console.warn ) {
+		console.warn( message );
+	}
+	QUnit.warnings.push( message );
+}

--- a/src/test.js
+++ b/src/test.js
@@ -550,6 +550,13 @@ function test( testName, expected, callback, async ) {
 	if ( arguments.length === 2 ) {
 		callback = expected;
 		expected = null;
+	} else if ( arguments.length === 3 && typeof expected !== "function" ) {
+		if ( global.console && global.console.warn ) {
+			global.console.warn(
+				"'expected' argument of QUnit.test is deprecated. " +
+				"Call the expect() function explicitly instead."
+			);
+		}
 	}
 
 	newTest = new Test({

--- a/src/test.js
+++ b/src/test.js
@@ -57,7 +57,8 @@ Test.prototype = {
 					failed: config.moduleStats.bad,
 					passed: config.moduleStats.all - config.moduleStats.bad,
 					total: config.moduleStats.all,
-					runtime: now() - config.moduleStats.started
+					runtime: now() - config.moduleStats.started,
+					warnings: QUnit.warnings
 				});
 			}
 			config.previousModule = this.module;
@@ -218,7 +219,8 @@ Test.prototype = {
 			source: this.stack,
 
 			// DEPRECATED: this property will be removed in 2.0.0, use runtime instead
-			duration: this.runtime
+			duration: this.runtime,
+			warnings: QUnit.warnings
 		});
 
 		// QUnit.reset() is deprecated and will be replaced for a new
@@ -280,7 +282,8 @@ Test.prototype = {
 				expected: expected,
 				testId: this.testId,
 				negative: negative || false,
-				runtime: now() - this.started
+				runtime: now() - this.started,
+				warnings: QUnit.warnings
 			};
 
 		if ( !result ) {
@@ -312,7 +315,8 @@ Test.prototype = {
 				message: message || "error",
 				actual: actual || null,
 				testId: this.testId,
-				runtime: now() - this.started
+				runtime: now() - this.started,
+				warnings: QUnit.warnings
 			};
 
 		if ( source ) {
@@ -551,12 +555,10 @@ function test( testName, expected, callback, async ) {
 		callback = expected;
 		expected = null;
 	} else if ( arguments.length === 3 && typeof expected !== "function" ) {
-		if ( global.console && global.console.warn ) {
-			global.console.warn(
-				"'expected' argument of QUnit.test is deprecated. " +
-				"Call the expect() function explicitly instead."
-			);
-		}
+		deprecateWarns(
+			"'expected' argument of QUnit.test is deprecated. " +
+			"Call the expect() function explicitly instead."
+		);
 	}
 
 	newTest = new Test({

--- a/test/logs.js
+++ b/test/logs.js
@@ -107,6 +107,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 	);
 
 	delete logContext.runtime;
+	delete logContext.warnings;
 	assert.deepEqual( logContext, {
 		name: module1Test1.name,
 		module: module1Context.name,
@@ -121,6 +122,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 	assert.equal( "foo", "foo" );
 
 	delete logContext.runtime;
+	delete logContext.warnings;
 	assert.deepEqual( logContext, {
 		name: module1Test1.name,
 		module: module1Context.name,
@@ -135,6 +137,7 @@ QUnit.test( module1Test1.name, function( assert ) {
 	assert.ok( true, "ok(true, message)" );
 
 	delete logContext.runtime;
+	delete logContext.warnings;
 	assert.deepEqual( logContext, {
 		module: module1Context.name,
 		name: module1Test1.name,
@@ -188,6 +191,7 @@ QUnit.test( module1Test2.name, function( assert ) {
 	// Delete testDoneContext.source
 	delete testDoneContext.source;
 
+	delete testDoneContext.warnings;
 	assert.deepEqual( testDoneContext, {
 		module: module1Context.name,
 		name: module1Test1.name,
@@ -230,6 +234,7 @@ QUnit.test( module2Test1.name, function( assert ) {
 		"module runtime was a reasonable number"
 	);
 	delete moduleDoneContext.runtime;
+	delete moduleDoneContext.warnings;
 
 	assert.deepEqual( moduleDoneContext, {
 		name: module1Context.name,
@@ -269,6 +274,7 @@ QUnit.test( module2Test4.name, function( assert ) {
 	delete testDoneContext.runtime;
 	delete testDoneContext.duration;
 	delete testDoneContext.source;
+	delete testDoneContext.warnings;
 
 	assert.deepEqual( testDoneContext, {
 		assertions: [],

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -7,6 +7,10 @@ QUnit.test( "expect query and multiple issue", function( assert ) {
 	assert.ok( true );
 });
 
+QUnit.test( "expected of QUnit.test is deprecated", 42, function( assert ) {
+	assert.expect( 0 );
+});
+
 if ( typeof document !== "undefined" ) {
 
 QUnit.module( "fixture" );

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -7,12 +7,19 @@ QUnit.test( "expect query and multiple issue", function( assert ) {
 	assert.ok( true );
 });
 
-QUnit.test( "expected of QUnit.test is deprecated", 42, function( assert ) {
-	assert.expect( 0 );
+if ( typeof document === "undefined" ) {
+
+QUnit.test("expected of QUnit.test is deprecated", 1, function( assert ) {
+	assert.equal(
+		QUnit.warnings[0],
+		"DEPRECATED: 'expected' argument of QUnit.test is deprecated. " +
+		"Call the expect() function explicitly instead."
+	);
 });
 
-if ( typeof document !== "undefined" ) {
+}
 
+if ( typeof document !== "undefined" ) {
 QUnit.module( "fixture" );
 
 QUnit.test( "setup", function( assert ) {


### PR DESCRIPTION
Fixes #356 

I left asyncTest untouched because of https://github.com/jquery/qunit/issues/656.