### PR TITLE
Update grunt to 0.4.5 and grunt-contrib-jshint to 0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "devDependencies": {
     "browserstack-runner": "0.3.7",
     "commitplease": "2.0.0",
-    "grunt": "0.4.2",
+    "grunt": "0.4.5",
     "grunt-concurrent": "2.0.3",
     "grunt-contrib-concat": "0.3.0",
-    "grunt-contrib-jshint": "0.11.2",
+    "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-watch": "0.5.3",
     "grunt-coveralls": "0.3.0",
     "grunt-git-authors": "3.0.0",


### PR DESCRIPTION
Update grunt to 0.4.5 which was release last year in may.

Also update grunt-contrib-jshint to 0.11.3 since it was using the very latest jshint version which is 2.9.0 which has regressions.