### PR TITLE
Core: Support filtering by regular expression

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,7 +107,10 @@ grunt.initConfig({
 			"test/reporter-html/legacy-markup.html",
 			"test/reporter-html/no-qunit-element.html",
 			"test/reporter-html/single-testid.html",
-			"test/only.html"
+			"test/only.html",
+			"test/regex-filter.html",
+			"test/regex-exclude-filter.html",
+			"test/string-filter.html"
 		]
 	},
 	coveralls: {

--- a/src/test.js
+++ b/src/test.js
@@ -356,10 +356,10 @@ Test.prototype = {
 	},
 
 	valid: function() {
-		var include,
-			filter = config.filter && config.filter.toLowerCase(),
+		var filter = config.filter,
+			regexFilter = /^(!?)\/([\w\W]*)\/(i?$)/.exec( filter ),
 			module = QUnit.urlParams.module && QUnit.urlParams.module.toLowerCase(),
-			fullName = ( this.module.name + ": " + this.testName ).toLowerCase();
+			fullName = ( this.module.name + ": " + this.testName );
 
 		function testInModuleChain( testModule ) {
 			var testModuleName = testModule.name ? testModule.name.toLowerCase() : null;
@@ -389,7 +389,23 @@ Test.prototype = {
 			return true;
 		}
 
-		include = filter.charAt( 0 ) !== "!";
+		return regexFilter ?
+			this.regexFilter( !!regexFilter[1], regexFilter[2], regexFilter[3], fullName ) :
+			this.stringFilter( filter, fullName );
+	},
+
+	regexFilter: function( exclude, pattern, flags, fullName ) {
+		var regex = new RegExp( pattern, flags );
+		var match = regex.test( fullName );
+
+		return match !== exclude;
+	},
+
+	stringFilter: function( filter, fullName ) {
+		filter = filter.toLowerCase();
+		fullName = fullName.toLowerCase();
+
+		var include = filter.charAt( 0 ) !== "!";
 		if ( !include ) {
 			filter = filter.slice( 1 );
 		}

--- a/test/regex-exclude-filter.html
+++ b/test/regex-exclude-filter.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>QUnit Regex Exclude Filtering Test Suite</title>
+		<link rel="stylesheet" href="../dist/qunit.css">
+		<script src="../dist/qunit.js"></script>
+		<script>
+			QUnit.config.filter = '!/Foo|bar/';
+		</script>
+		<script src="regex-exclude-filter.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+	</body>
+</html>

--- a/test/regex-exclude-filter.js
+++ b/test/regex-exclude-filter.js
@@ -1,0 +1,17 @@
+QUnit.module( "QUnit.config.filter with excluding, case-sensitive regular expression" );
+
+QUnit.test( "foo test should be run", function( assert ) {
+	assert.ok( true, "foo test should be run" );
+});
+
+QUnit.test( "Foo test should not be run", function( assert ) {
+	assert.ok( false, "Foo test should not be run" );
+});
+
+QUnit.test( "Bar test should be run", function( assert ) {
+	assert.ok( true, "Bar test should be run" );
+});
+
+QUnit.test( "bar test should not be run", function( assert ) {
+	assert.ok( false, "bar test should not be run" );
+});

--- a/test/regex-filter.html
+++ b/test/regex-filter.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>QUnit Regex Filtering Test Suite</title>
+		<link rel="stylesheet" href="../dist/qunit.css">
+		<script src="../dist/qunit.js"></script>
+		<script>
+			QUnit.config.filter = '/foo|bar/i';
+		</script>
+		<script src="regex-filter.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+	</body>
+</html>

--- a/test/regex-filter.js
+++ b/test/regex-filter.js
@@ -1,0 +1,17 @@
+QUnit.module( "QUnit.config.filter with case-insensitive regular expression" );
+
+QUnit.test( "foo test should be run", function( assert ) {
+	assert.ok( true, "foo test should be run" );
+});
+
+QUnit.test( "boo test should not be run", function( assert ) {
+	assert.ok( false, "boo test should not be run" );
+});
+
+QUnit.test( "bar test should be run", function( assert ) {
+	assert.ok( true, "bar test should be run" );
+});
+
+QUnit.test( "baz test should not be run", function( assert ) {
+	assert.ok( false, "baz test should not be run" );
+});

--- a/test/string-filter.html
+++ b/test/string-filter.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>QUnit String Filtering Test Suite</title>
+		<link rel="stylesheet" href="../dist/qunit.css">
+		<script src="../dist/qunit.js"></script>
+		<script>
+			QUnit.config.filter = '!foo|bar';
+		</script>
+		<script src="string-filter.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+	</body>
+</html>

--- a/test/string-filter.js
+++ b/test/string-filter.js
@@ -1,0 +1,13 @@
+QUnit.module( "QUnit.config.filter" );
+
+QUnit.test( "foo test should be run", function( assert ) {
+	assert.ok( true, "foo test should be run" );
+});
+
+QUnit.test( "bar test should be run", function( assert ) {
+	assert.ok( true, "bar test should be run" );
+});
+
+QUnit.test( "foo|bar test should not be run", function( assert ) {
+	assert.ok( false, "baz test should not be run" );
+});


### PR DESCRIPTION
Introduces a "regexFilter" config option that, when enabled, treats the "filter"
value as a regular expression to test against instead of a string.

Fixes: #904 