### PR TITLE
Assert: Improve size and speed of QUnit.equiv

### DIFF
--- a/src/equiv.js
+++ b/src/equiv.js
@@ -9,6 +9,12 @@ QUnit.equiv = (function() {
 	var parents = [];
 	var parentsB = [];
 
+	var getProto = Object.getPrototypeOf || function( obj ) {
+
+		/*jshint proto: true */
+		return obj.__proto__;
+	};
+
 	function useStrictEquality( b, a ) {
 
 		// To catch short annotation VS 'new' annotation of a declaration. e.g.:
@@ -25,11 +31,6 @@ QUnit.equiv = (function() {
 	}
 
 	function compareConstructors( a, b ) {
-		var getProto = Object.getPrototypeOf || function( obj ) {
-
-			/*jshint proto: true */
-			return obj.__proto__;
-		};
 		var protoA = getProto( a );
 		var protoB = getProto( b );
 
@@ -65,25 +66,17 @@ QUnit.equiv = (function() {
 		"null": useStrictEquality,
 		"undefined": useStrictEquality,
 		"symbol": useStrictEquality,
+		"date": useStrictEquality,
 
-		"nan": function( b ) {
-			return isNaN( b );
-		},
-
-		"date": function( b, a ) {
-			return QUnit.objectType( b ) === "date" && a.valueOf() === b.valueOf();
+		"nan": function() {
+			return true;
 		},
 
 		"regexp": function( b, a ) {
-			return QUnit.objectType( b ) === "regexp" &&
+			return a.source === b.source &&
 
-				// The regex itself
-				a.source === b.source &&
-
-				// And its modifiers
+				// Include flags in the comparison
 				a.global === b.global &&
-
-				// (gmi) ...
 				a.ignoreCase === b.ignoreCase &&
 				a.multiline === b.multiline &&
 				a.sticky === b.sticky;
@@ -99,11 +92,6 @@ QUnit.equiv = (function() {
 
 		"array": function( b, a ) {
 			var i, j, len, loop, aCircular, bCircular;
-
-			// b could be an object literal here
-			if ( QUnit.objectType( b ) !== "array" ) {
-				return false;
-			}
 
 			len = a.length;
 			if ( len !== b.length ) {
@@ -143,11 +131,6 @@ QUnit.equiv = (function() {
 		"set": function( b, a ) {
 			var aArray, bArray;
 
-			// `b` could be any object here
-			if ( QUnit.objectType( b ) !== "set" ) {
-				return false;
-			}
-
 			aArray = [];
 			a.forEach( function( v ) {
 				aArray.push( v );
@@ -162,11 +145,6 @@ QUnit.equiv = (function() {
 
 		"map": function( b, a ) {
 			var aArray, bArray;
-
-			// `b` could be any object here
-			if ( QUnit.objectType( b ) !== "map" ) {
-				return false;
-			}
 
 			aArray = [];
 			a.forEach( function( v, k ) {
@@ -239,37 +217,23 @@ QUnit.equiv = (function() {
 	};
 
 	function typeEquiv( a, b ) {
-		var prop = QUnit.objectType( a );
-		return callbacks[ prop ]( b, a );
+		var type = QUnit.objectType( a );
+		return QUnit.objectType( b ) === type && callbacks[ type ]( b, a );
 	}
 
 	// The real equiv function
-	function innerEquiv() {
-		var args = [].slice.apply( arguments );
-		if ( args.length < 2 ) {
+	function innerEquiv( a, b ) {
 
-			// End transition
+		// We're done when there's nothing more to compare
+		if ( arguments.length < 2 ) {
 			return true;
 		}
 
-		return ( (function( a, b ) {
-			if ( a === b ) {
+		// Require type-specific equality
+		return ( a === b || typeEquiv( a, b ) ) &&
 
-				// Catch the most you can
-				return true;
-			} else if ( a === null || b === null || typeof a === "undefined" ||
-					typeof b === "undefined" ||
-					QUnit.objectType( a ) !== QUnit.objectType( b ) ) {
-
-				// Don't lose time with error prone cases
-				return false;
-			} else {
-				return typeEquiv( a, b );
-			}
-
-		// Apply transition with (1..n) arguments
-		}( args[ 0 ], args[ 1 ] ) ) &&
-			innerEquiv.apply( this, args.splice( 1, args.length - 1 ) ) );
+			// ...across all consecutive argument pairs
+			( arguments.length === 2 || innerEquiv.apply( this, [].slice.call( arguments, 1 ) ) );
 	}
 
 	return innerEquiv;


### PR DESCRIPTION
Inspired by gh-895 review. Inner comparisons are always `QUnit.objectType`-equal.