### PR TITLE
Give hidden test results a non-static parent

### DIFF
--- a/src/qunit.css
+++ b/src/qunit.css
@@ -120,6 +120,10 @@
 	display: list-item;
 }
 
+#qunit-tests.hidepass {
+	position: relative;
+}
+
 #qunit-tests.hidepass li.running,
 #qunit-tests.hidepass li.pass {
 	visibility: hidden;


### PR DESCRIPTION
Hi, 

we recently upgraded from **QUnit 1.16.0** to **1.18.0** and noticed that one of our tests now crashes IE11 / Edge (the same occurs when running against QUnit **1.20.0**). 

We managed to reduce the failing test to a quite simple one, see http://output.jsbin.com/texavejibu/?hidepassed . When run without hidepassed, the test succeeds and completes as expected. But when run on IE11 / Edge with parameter hidepassed, the test does not complete (e.g. color indicator for final result doesn't become visible) and - after some mouse moving or clicking anywhere, IE crashes regularly (alert "Internet Explorer has stopped working" pops up). 

IE11 version is 11.0.9600.18163, Update Versions 27 (KB3124275). 

Interestingly, resizing the browser after the problem occurred but before raising other events, also fixes it - quite strange :-)

This looks like a clear browser bug. However, it only appears due to commit db4e491 associated with #737. That commit modified the CSS `position` property for the `<ol>` and `<li>` elements in the test results to `position:absolute`. 
QUnit can help IE11 to "survive" the above test by giving those items a well-defined, non-static parent. I tried with 

```css
#qunit-tests.hidepassed { 
    position:relative;
}
```
and that fixed the issue for us. As this seems not to do any harm, I propose to add it to qunit.css.

Kind Regards, cw