### PR TITLE
Support deprecated assert methods in environments other than browsers.

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -1,23 +1,23 @@
+// Deprecated
+// Extend assert methods to QUnit for Backwards compatibility
+(function() {
+	var i,
+		assertions = Assert.prototype;
+
+	function applyCurrent( current ) {
+		return function() {
+			var assert = new Assert( QUnit.config.current );
+			current.apply( assert, arguments );
+		};
+	}
+
+	for ( i in assertions ) {
+		QUnit[ i ] = applyCurrent( assertions[ i ] );
+	}
+})();
+
 // For browser, export only select globals
 if ( defined.document ) {
-
-	// Deprecated
-	// Extend assert methods to QUnit and Global scope through Backwards compatibility
-	(function() {
-		var i,
-			assertions = Assert.prototype;
-
-		function applyCurrent( current ) {
-			return function() {
-				var assert = new Assert( QUnit.config.current );
-				current.apply( assert, arguments );
-			};
-		}
-
-		for ( i in assertions ) {
-			QUnit[ i ] = applyCurrent( assertions[ i ] );
-		}
-	})();
 
 	(function() {
 		var i, l,


### PR DESCRIPTION
The way QUnit currently exposes deprecated assert methods on the global QUnit object only works in browsers, because the code is wrapped by a check for `defined.document`.

I am using QUnit for hybrid tests inside Node.js as well as in a browser environment through PhantomJS (as part of my new gulp plugin for such hybrid test scenarios, see https://github.com/lehni/gulp-qunits), and I expect it to behave the same way in both environments.

At the moment, the Node QUnit Runner needs to use such trickery to make this work, it would be nice to be able to get rid of it:

```js
// Abuse a test to fetch the assert object along with its prototype and methods.
QUnit.test('setup', function(assert) {
    var Assert = assert.constructor,
        asserts = Object.getPrototypeOf(assert);
    Object.keys(asserts).forEach(function(key) {
        var current = asserts[key];
        global[key] = QUnit[key] = function() {
            current.apply(new Assert(QUnit.config.current), arguments);
        };
    });
    assert.expect(0);
});
```