### PR TITLE
Remove browserstack runs on legacy browsers

### DIFF
--- a/build/browserstack-legacy-1.json
+++ b/build/browserstack-legacy-1.json
@@ -10,11 +10,6 @@
 		"chrome_previous",
 		"firefox_previous",
 		"opera_previous",
-		"safari_5_1",
-		{
-			"browser": "safari",
-			"browser_version": "6.0"
-		},
 		{
 			"browser": "safari",
 			"browser_version": "8.0"

--- a/build/browserstack-legacy-1.json
+++ b/build/browserstack-legacy-1.json
@@ -19,9 +19,6 @@
 			"browser": "safari",
 			"browser_version": "8.0"
 		},
-		"ie_6",
-		"ie_7",
-		"ie_8",
 		"ie_9",
 		"ie_10",
 		{

--- a/build/browserstack-legacy-2.json
+++ b/build/browserstack-legacy-2.json
@@ -11,11 +11,6 @@
 		"chrome_previous",
 		"firefox_previous",
 		"opera_previous",
-		"safari_5_1",
-		{
-			"browser": "safari",
-			"browser_version": "6.0"
-		},
 		{
 			"browser": "safari",
 			"browser_version": "8.0"

--- a/build/browserstack-legacy-2.json
+++ b/build/browserstack-legacy-2.json
@@ -20,9 +20,6 @@
 			"browser": "safari",
 			"browser_version": "8.0"
 		},
-		"ie_6",
-		"ie_7",
-		"ie_8",
 		"ie_9",
 		"ie_10",
 		{


### PR DESCRIPTION
Removing IE 6, 7, and 8, Safari 5.1 and 6.

@mgol, I want to sync this up with jQuery Core while QUnit is still on 1.x.

