### PR TITLE
Build: Add grunt-cli to devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "0.10"
 before_install:
-  - npm install -g grunt-cli
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19VU0VSTkFNRT1icm93c2Vyc3RhY2txdW5pMQo=`
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19LRVk9SllzeHJrVWk5aGJGVndkdW44ZUsK=`
 script:

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ For related discussions, visit the
 ## Development
 
 To submit patches, fork the repository, create a branch for the change. Then implement
-the change, run `grunt` to lint and test it, then commit, push and create a pull request.
+the change, run `npm test` to lint and test it, then commit, push and create a pull request.
 
 Include some background for the change in the commit message and `Fixes #nnn`, referring
 to the issue number you're addressing.
 
-To run `grunt`, you need [Node.js](https://nodejs.org/download/), which includes `npm`, then `npm install -g grunt-cli`. That gives you a global grunt binary. For additional grunt tasks, also run `npm install`.
+To run `npm test`, you need [Node.js](https://nodejs.org/download/), which includes `npm`.
 
 ## Releases
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "browserstack-runner": "0.3.7",
     "commitplease": "2.0.0",
     "grunt": "0.4.5",
+    "grunt-cli": "0.1.13",
     "grunt-concurrent": "2.0.3",
     "grunt-contrib-concat": "0.3.0",
     "grunt-contrib-jshint": "0.11.2",


### PR DESCRIPTION
Removes need for custom code in .travis.yml, and makes it so that
`npm install && npm test` works out of the box without requiring
grunt-cli pre-installed.

This works because npm always makes exported bin commands available via the local `node_modules/.bin` directory in the environment PATH as used by of npm commands.