### PR TITLE
Tests: Fix QUnit.stack test to account different path systems

### DIFF
--- a/test/main/stack.js
+++ b/test/main/stack.js
@@ -5,7 +5,7 @@
 
 	// Flag this test as skipped on browsers that doesn't support stack trace
 	QUnit[ stack ? "test" : "skip" ]( "returns the proper stack line", function( assert ) {
-		assert.ok( /\/test\/main\/stack\.js/.test( stack ) );
+		assert.ok( /(\/|\\)test(\/|\\)main(\/|\\)stack\.js/.test( stack ) );
 
 		stack = QUnit.stack( 2 );
 		assert.ok( stack, "can use offset argument to return a different stacktrace line" );


### PR DESCRIPTION
Fixes #940

Let's check how this goes on the CI.

That was the last bug to fix #940 and have a fine development suite on Windows.