### PR TITLE
Fix asymmetrical function dump argument spacing.

### DIFF
--- a/src/dump.js
+++ b/src/dump.js
@@ -150,7 +150,7 @@ QUnit.dump = ( function() {
 					if ( name ) {
 						ret += " " + name;
 					}
-					ret += "( ";
+					ret += "(";
 
 					ret = [ ret, dump.parse( fn, "functionArgs" ), "){" ].join( "" );
 					return join( ret, dump.parse( fn, "functionCode" ), "}" );


### PR DESCRIPTION
The `functionArgs` parser adds a space before and after the list of arguments, so the `function` parser does not need to add one after the opening bracket of the argument list.