### PR TITLE
Build: Introduce AppVeyor for Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+# https://www.appveyor.com/docs/build-configuration
+
+# Test against this version of Node.js
+environment:
+  nodejs_version: "4"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off


### PR DESCRIPTION
Introduces a simple AppVeyor config to enable Windows CI as discussed in #943.

Edit: Unfortunately, looks like it won't actually do an AppVeyor build until after the config has been committed.