### PR TITLE
Readme: Add AppVeyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/jquery/qunit.svg?branch=master)](https://travis-ci.org/jquery/qunit) [![Coverage Status](https://coveralls.io/repos/jquery/qunit/badge.svg)](https://coveralls.io/github/jquery/qunit)
+[![Travis Build Status](https://travis-ci.org/jquery/qunit.svg?branch=master)](https://travis-ci.org/jquery/qunit) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/jquery/qunit?svg=true&branch=master)](https://ci.appveyor.com/project/leobalter/qunit) [![Coverage Status](https://coveralls.io/repos/jquery/qunit/badge.svg)](https://coveralls.io/github/jquery/qunit)
 
 # [QUnit](https://qunitjs.com) - A JavaScript Unit Testing Framework.
 


### PR DESCRIPTION
Adding a badge for the AppVeyor build. Also testing to make sure AppVeyor picks up PRs.

It looks like AppVeyor hosts the project under the account name, which in this case is my username, so the CI url is: https://ci.appveyor.com/project/trentmwillis/qunit. Is there or should we set up a "jquery" account so that the URL can look more correct? If so, who can do that?