### PR TITLE
Core: Handle multiple moduleId parameters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,6 +113,7 @@ grunt.initConfig( {
 			"test/reporter-html/legacy-markup.html",
 			"test/reporter-html/no-qunit-element.html",
 			"test/reporter-html/single-testid.html",
+			"test/moduleId.html",
 			"test/only.html",
 			"test/random.html",
 			"test/regex-filter.html",

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -310,7 +310,10 @@ function applyUrlParams() {
 		filter: ( filter === "" ) ? undefined : filter,
 
 		// Remove testId filter
-		testId: undefined
+		testId: undefined,
+
+		// Remove moduleId filter
+		moduleId: undefined
 	} );
 }
 

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -90,12 +90,15 @@ if ( urlParams.seed ) {
 	}
 }
 
-config.testId = [];
-if ( urlParams.testId ) {
+function getIds ( params ) {
+	var paramArray = [];
+	if ( params ) {
 
-	// Ensure that urlParams.testId is an array
-	urlParams.testId = decodeURIComponent( urlParams.testId ).split( "," );
-	for ( var i = 0; i < urlParams.testId.length; i++ ) {
-		config.testId.push( urlParams.testId[ i ] );
+		// Ensure that params is an array
+		paramArray = decodeURIComponent( params ).split( "," );
 	}
+	return paramArray;
 }
+
+config.testId = getIds( urlParams.testId );
+config.moduleId = getIds( urlParams.moduleId );

--- a/src/test.js
+++ b/src/test.js
@@ -360,7 +360,8 @@ Test.prototype = {
 	},
 
 	valid: function() {
-		var filter = config.filter,
+		var moduleId,
+			filter = config.filter,
 			regexFilter = /^(!?)\/([\w\W]*)\/(i?$)/.exec( filter ),
 			module = QUnit.urlParams.module && QUnit.urlParams.module.toLowerCase(),
 			fullName = ( this.module.name + ": " + this.testName );
@@ -379,6 +380,13 @@ Test.prototype = {
 		// Internally-generated tests are always valid
 		if ( this.callback && this.callback.validTest ) {
 			return true;
+		}
+
+		if ( config.moduleId.length >  0 ) {
+			moduleId = generateHash( this.module.name );
+			if ( inArray( moduleId, config.moduleId ) < 0 ) {
+				return false;
+			}
 		}
 
 		if ( config.testId.length > 0 && inArray( this.testId, config.testId ) < 0 ) {

--- a/test/moduleId.html
+++ b/test/moduleId.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>QUnit ModuleId Test Suite</title>
+		<link rel="stylesheet" href="../dist/qunit.css">
+		<script src="../dist/qunit.js"></script>
+		<script src="moduleId.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+	</body>
+</html>

--- a/test/moduleId.js
+++ b/test/moduleId.js
@@ -1,0 +1,19 @@
+QUnit.config.moduleId = [ "720ab266", "0af5a573" ];
+
+QUnit.module( "QUnit.config.moduleId.foo" );
+
+QUnit.test( "foo test should be run", function( assert ) {
+	assert.ok( true, "foo test should be run" );
+} );
+
+QUnit.module( "QUnit.config.moduleId.bar" );
+
+QUnit.test( "bar test should be run", function( assert ) {
+	assert.ok( true, "bar test should be run" );
+} );
+
+QUnit.module( "QUnit.config.moduleId.foobar" );
+
+QUnit.test( "foobar test should not be run", function( assert ) {
+	assert.ok( false, "foobar test should not be run" );
+} );


### PR DESCRIPTION
What: Adding moduleId support for multiple module ids
Why: Enable users to run a subset of all modules, rather than one/all modules. Adds symmetry to the existing testId feature.This will enable UI improvements, which we can now explore.