### PR TITLE
Core: Stop splitting URL parameter values by commas

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -281,10 +281,9 @@ function setUrl( params ) {
 	params = QUnit.extend( QUnit.extend( {}, QUnit.urlParams ), params );
 
 	for ( key in params ) {
-		if ( hasOwn.call( params, key ) ) {
-			if ( params[ key ] === undefined ) {
-				continue;
-			}
+
+		// Skip inherited or undefined properties
+		if ( hasOwn.call( params, key ) && params[ key ] !== undefined ) {
 
 			// Output a parameter for each value of this key (but usually just one)
 			arrValue = [].concat( params[ key ] );

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -275,7 +275,7 @@ function toolbarChanged() {
 }
 
 function setUrl( params ) {
-	var key,
+	var key, arrValue, i,
 		querystring = "?";
 
 	params = QUnit.extend( QUnit.extend( {}, QUnit.urlParams ), params );
@@ -285,11 +285,16 @@ function setUrl( params ) {
 			if ( params[ key ] === undefined ) {
 				continue;
 			}
-			querystring += encodeURIComponent( key );
-			if ( params[ key ] !== true ) {
-				querystring += "=" + encodeURIComponent( params[ key ] );
+
+			// Output a parameter for each value of this key (but usually just one)
+			arrValue = [].concat( params[ key ] );
+			for ( i = 0; i < arrValue.length; i++ ) {
+				querystring += encodeURIComponent( key );
+				if ( arrValue[ i ] !== true ) {
+					querystring += "=" + encodeURIComponent( arrValue[ i ] );
+				}
+				querystring += "&";
 			}
-			querystring += "&";
 		}
 	}
 	return location.protocol + "//" + location.host +

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -90,15 +90,6 @@ if ( urlParams.seed ) {
 	}
 }
 
-function getIds ( params ) {
-	var paramArray = [];
-	if ( params ) {
-
-		// Ensure that params is an array
-		paramArray = decodeURIComponent( params ).split( "," );
-	}
-	return paramArray;
-}
-
-config.testId = getIds( urlParams.testId );
-config.moduleId = getIds( urlParams.moduleId );
+// Force array-valued testId and moduleId configuration values
+config.testId = [].concat( urlParams.testId || [] );
+config.moduleId = [].concat( urlParams.moduleId || [] );


### PR DESCRIPTION
Repeating parameters is the preferred mechanism for specifying
multi-valued options by URL.

Fixes gh-954

Since we don't have any documentation of URL parameters, this doesn't break an official API.