### PR TITLE
Build: Update browserstack-runner from 0.3.7 to 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {},
   "devDependencies": {
     "async": "1.4.2",
-    "browserstack-runner": "0.3.7",
+    "browserstack-runner": "0.4.2",
     "commitplease": "2.0.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
This update is necessary to stop using the 3rd version of the BrowserStack API.

Fixes #958