### PR TITLE
Build: Remove browserstack-runner from CI tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "browserstack": "sh build/run-browserstack.sh",
-    "ci": "grunt && grunt coveralls && npm run browserstack",
+    "ci": "grunt && grunt coveralls",
     "test": "grunt",
     "prepublish": "grunt build"
   },


### PR DESCRIPTION
The new updated version of browserstack-runner (0.4.x) is returning a
constant timeout failure on the amd tests.

Instead of reverting browserstack-runner back to the previous and
deprecated version (0.3.x), we should investigate the current error
and find a proper fix. The old version is expected to stop working
soon, as Browserstack will maintain compatibility only to the new
version.

Ref gh-959