### PR TITLE
Core: Implement moduleId support for nested modules

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -56,7 +56,8 @@ extend( QUnit, {
 			var module = {
 				name: moduleName,
 				parentModule: parentModule,
-				tests: []
+				tests: [],
+				moduleId: generateHash( moduleName )
 			};
 
 			var env = {};

--- a/test/moduleId.js
+++ b/test/moduleId.js
@@ -1,4 +1,4 @@
-QUnit.config.moduleId = [ "720ab266", "0af5a573" ];
+QUnit.config.moduleId = [ "720ab266", "0af5a573", "64f7439b", "8fdbddfe" ];
 
 QUnit.module( "QUnit.config.moduleId.foo" );
 
@@ -16,4 +16,30 @@ QUnit.module( "QUnit.config.moduleId.foobar" );
 
 QUnit.test( "foobar test should not be run", function( assert ) {
 	assert.ok( false, "foobar test should not be run" );
+} );
+
+QUnit.module( "QUnit.config.moduleId.parentModule1", function() {
+  QUnit.module( "Qunit.config.module.parentModule1.module1", function() {
+    QUnit.test( "submodule should run", function( assert ) {
+      assert.ok( true, "submodule test should run" );
+    } );
+  } );
+  QUnit.module( "Qunit.config.module.parentModule.module2", function() {
+    QUnit.test( "submodule should run", function( assert ) {
+      assert.ok( true, "submodule test should run" );
+    } );
+  } );
+} );
+
+QUnit.module( "QUnit.config.moduleId.parentModule2", function() {
+  QUnit.module( "Qunit.config.module.parentModule2.module1", function() {
+    QUnit.test( "submodule should run", function( assert ) {
+      assert.ok( true, "submodule test should run" );
+    } );
+  } );
+  QUnit.module( "Qunit.config.module.parentModule.module1", function() {
+    QUnit.test( "submodule should not run", function( assert ) {
+      assert.ok( false, "submodule test should not run" );
+    } );
+  } );
 } );


### PR DESCRIPTION
What: Supporting module nesting when filtering by `moduleId`. Also registering `moduleId` on the module itself to be consistent with `testId`.
Why: `moduleId` param did not support module nesting.