### PR TITLE
Build: Split BrowserStack and Tests into separate Travis processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,18 @@ sudo: false
 language: node_js
 node_js:
   - "4"
+env:
+  - NPM_SCRIPT=ci
+  - NPM_SCRIPT=browserstack
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: NPM_SCRIPT=browserstack
 before_install:
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19VU0VSTkFNRT1icm93c2Vyc3RhY2txdW5pMQo=`
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19LRVk9SllzeHJrVWk5aGJGVndkdW44ZUsK=`
 script:
-  - npm run-script ci
+  - npm run-script $NPM_SCRIPT
 cache:
   directories:
     - node_modules

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "browserstack": "sh build/run-browserstack.sh",
-    "ci": "grunt && grunt coveralls && npm run browserstack",
+    "ci": "grunt && grunt coveralls",
     "test": "grunt",
     "prepublish": "grunt build"
   },


### PR DESCRIPTION
Bringing this up as an alternative to #960. This will run BrowserStack and the actual Tests in different Travis processes. It will also allow BrowserStack to fail without reporting the entire build as a failure.