### PR TITLE
Build: Update browserstack-runner to 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {},
   "devDependencies": {
     "async": "1.4.2",
-    "browserstack-runner": "0.4.2",
+    "browserstack-runner": "0.4.3",
     "commitplease": "2.0.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
Fixes issue with specific test pages with RequireJS (`amd.html`) timing out on BrowserStack.

More info [here](https://github.com/browserstack/browserstack-runner/pull/154).