### PR TITLE
Core: Reintroduce QUnit.config.module

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -80,6 +80,9 @@ if ( urlParams.filter === true ) {
 // String search anywhere in moduleName+testName
 config.filter = urlParams.filter;
 
+// Exact match of the module name
+config.module = urlParams.module;
+
 // Randomize the order in which tests are run
 if ( urlParams.seed ) {
 	config.seed = urlParams.seed;

--- a/src/test.js
+++ b/src/test.js
@@ -362,7 +362,7 @@ Test.prototype = {
 	valid: function() {
 		var filter = config.filter,
 			regexFilter = /^(!?)\/([\w\W]*)\/(i?$)/.exec( filter ),
-			module = QUnit.urlParams.module && QUnit.urlParams.module.toLowerCase(),
+			module = config.module && config.module.toLowerCase(),
 			fullName = ( this.module.name + ": " + this.testName );
 
 		function moduleChainNameMatch( testModule ) {

--- a/test/module-filter.html
+++ b/test/module-filter.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>QUnit Module Filter Test Suite</title>
+    <link rel="stylesheet" href="../dist/qunit.css">
+    <script src="../dist/qunit.js"></script>
+    <script src="module-filter.js"></script>
+  </head>
+  <body>
+    <div id="qunit"></div>
+  </body>
+</html>

--- a/test/module-filter.js
+++ b/test/module-filter.js
@@ -1,0 +1,53 @@
+QUnit.config.module = "Foo";
+
+QUnit.module( "Foo" );
+
+QUnit.test( "Foo test should be run", function( assert ) {
+  assert.ok( true, "Foo test should be run" );
+} );
+
+QUnit.module( "foo" );
+
+QUnit.test( "foo test should be run", function( assert ) {
+  assert.ok( true, "foo test should be run" );
+} );
+
+QUnit.module( "Bar" );
+
+QUnit.test( "Bar test should not be run", function( assert ) {
+  assert.ok( false, "Bar test should not be run" );
+} );
+
+QUnit.module( "Foo Bar" );
+
+QUnit.test( "Foo Bar test should not be run", function( assert ) {
+  assert.ok( false, "Foo Bar test should not be run" );
+} );
+
+QUnit.module( "Foo", function() {
+  QUnit.module( "Bar", function() {
+    QUnit.test( "Bar submodule test should run", function( assert ) {
+      assert.ok( true, "Bar submodule test should run" );
+    } );
+  } );
+
+  QUnit.module( "Boo", function() {
+    QUnit.test( "Boo submodule test should run", function( assert ) {
+      assert.ok( true, "Boo submodule test should run" );
+    } );
+  } );
+} );
+
+QUnit.module( "Bar", function() {
+  QUnit.module( "Foo", function() {
+    QUnit.test( "Foo submodule test should not run", function( assert ) {
+      assert.ok( false, "Foo submodule test should not run" );
+    } );
+  } );
+
+  QUnit.module( "Boo", function() {
+    QUnit.test( "Boo submodule test should not run", function( assert ) {
+      assert.ok( false, "Boo submodule test should not run" );
+    } );
+  } );
+} );


### PR DESCRIPTION
For #956. I did realize in working on this that using `module` as opposed to `moduleFilter` can be a little confusing. That said, without also modifying the name of the url parameter, I think this is the best option.