### PR TITLE
Core: Add `test` method to `hooks` object.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -33,7 +33,8 @@ extend( QUnit, {
 
 		moduleFns = {
 			beforeEach: setHook( module, "beforeEach" ),
-			afterEach: setHook( module, "afterEach" )
+			afterEach: setHook( module, "afterEach" ),
+			test: QUnit.test
 		};
 
 		if ( objectType( executeNow ) === "function" ) {

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -206,6 +206,7 @@ QUnit.module( "contained suite arguments", function( hooks ) {
 	QUnit.test( "hook functions", function( assert ) {
 		assert.strictEqual( typeof hooks.beforeEach, "function" );
 		assert.strictEqual( typeof hooks.afterEach, "function" );
+		assert.strictEqual( hooks.test, QUnit.test );
 	} );
 
 	QUnit.module( "outer hooks", function( hooks ) {


### PR DESCRIPTION
Provides an alias for `QUnit.test` to allow a more natural, nested nested api; this allows the author to write their tests as follows:

```js
QUnit.module('action/example', t => {
    t.beforeEach(/* ... */);
    t.test('it should be awesome', assert => {
    	assert.ok(true, 'rock and roll!');
    }
})
```

The downside I can see to this change is that it moves the existing convention away from the `t` / `hooks` argument being solely based around adding module hooks, however I feel there is a real benefit from not having to constantly write `QUnit` everywhere :grin: 

Thanks!