### PR TITLE
unquote reserved word throws off our compiler.

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -259,6 +259,7 @@ QUnit.assert = Assert.prototype = {
 // Provide an alternative to assert.throws(), for environments that consider throws a reserved word
 // Known to us are: Closure Compiler, Narwhal
 ( function() {
+	/*jshint sub:true */
 	Assert.prototype.raises = Assert.prototype [ "throws" ]; //jscs:ignore requireDotNotation
 }() );
 

--- a/src/assert.js
+++ b/src/assert.js
@@ -259,8 +259,7 @@ QUnit.assert = Assert.prototype = {
 // Provide an alternative to assert.throws(), for environments that consider throws a reserved word
 // Known to us are: Closure Compiler, Narwhal
 ( function() {
-	/*jshint sub:true */
-	Assert.prototype.raises = Assert.prototype [ "throws" ];
+	Assert.prototype.raises = Assert.prototype [ "throws" ]; //jscs:ignore requireDotNotation
 }() );
 
 function errorString( error ) {

--- a/src/assert.js
+++ b/src/assert.js
@@ -260,7 +260,7 @@ QUnit.assert = Assert.prototype = {
 // Known to us are: Closure Compiler, Narwhal
 ( function() {
 	/*jshint sub:true */
-	Assert.prototype.raises = Assert.prototype.throws;
+	Assert.prototype.raises = Assert.prototype["throws"];
 }() );
 
 function errorString( error ) {

--- a/src/assert.js
+++ b/src/assert.js
@@ -260,7 +260,7 @@ QUnit.assert = Assert.prototype = {
 // Known to us are: Closure Compiler, Narwhal
 ( function() {
 	/*jshint sub:true */
-	Assert.prototype.raises = Assert.prototype["throws"];
+	Assert.prototype.raises = Assert.prototype [ "throws" ];
 }() );
 
 function errorString( error ) {


### PR DESCRIPTION
Rogue, unquoted reserved word cause our complier to fail.
fixed with functionally identical version that should have been there in the first place, according to context