### PR TITLE
HTML Reporter: Improve toolbar styles & accessibility

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -295,15 +295,16 @@ function toolbarLooseFilter() {
 }
 
 function moduleListHtml () {
-	var i,
+	var i, checked,
 		html = "";
 
 	for ( i = 0; i < config.modules.length; i++ ) {
 		if ( config.modules[ i ].name !== "" ) {
-			html += "<li><label><input type='checkbox' " +
-			"module-id='" + config.modules[ i ].moduleId + "'" +
-			( config.moduleId.indexOf( config.modules[ i ].moduleId ) > -1 ? " checked" : "" ) +
-			">" + escapeText( config.modules[ i ].name ) + "</label></li>";
+			checked = config.moduleId.indexOf( config.modules[ i ].moduleId ) > -1;
+			html += "<li><label class='clickable" + ( checked ? " checked" : "" ) +
+				"'><input type='checkbox' " + "module-id='" + config.modules[ i ].moduleId + "'" +
+				( checked ? " checked" : "" ) + ">" + escapeText( config.modules[ i ].name ) +
+				"</label></li>";
 		}
 	}
 
@@ -325,20 +326,25 @@ function toolbarModuleFilter () {
 	label.innerHTML = "Module: ";
 	label.appendChild( moduleSearch );
 
-	clearFilter.id = "qunit-modulefilter-clear";
-	clearFilter.innerHTML = "<label><a href='" + escapeText( unfilteredUrl ) +
-		"'>All modules<a/></label>";
-	addEvent( clearFilter, "click", function() {
+	clearFilter.id = "qunit-modulefilter-actions";
+	clearFilter.innerHTML = "<a class='clickable" + ( config.moduleId.length ? "" : " checked" ) +
+		"' href='" + escapeText( unfilteredUrl ) + "'>All modules</a>";
+	addEvent( clearFilter.firstChild, "click", function( evt ) {
 		var i,
 			modulesList = dropDownList.getElementsByTagName( "input" );
 		for ( i = 0; i < modulesList.length; i++ )  {
 			modulesList[ i ].checked = false;
 		}
+
 		applyUrlParams();
+		evt.preventDefault();
 	} );
 
 	dropDownList.id = "qunit-modulefilter-dropdown-list";
 	dropDownList.innerHTML = moduleListHtml();
+	addEvent( dropDownList, "change", function( evt ) {
+		toggleClass( evt.target.parentNode, "checked", evt.target.checked );
+	} );
 
 	dropDown.id = "qunit-modulefilter-dropdown";
 	dropDown.style.display = "none";

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -169,12 +169,12 @@
 	font: smaller/1.5em sans-serif;
 }
 
-#qunit-modulefilter-actions > * {
+#qunit-modulefilter-dropdown #qunit-modulefilter-actions > * {
 	display: table-cell;
 	padding: 0.4em 0;
 }
 
-#qunit-modulefilter-actions > :first-child {
+#qunit-modulefilter-dropdown #qunit-modulefilter-actions > :first-child {
 	/* insert padding to align with checkbox margins */
 	padding-left: 3px;
 }

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -58,14 +58,14 @@
 
 #qunit-filteredTest {
 	padding: 0.5em 1em 0.5em 1em;
-	background-color: #F4FF77;
 	color: #366097;
+	background-color: #F4FF77;
 }
 
 #qunit-userAgent {
 	padding: 0.5em 1em 0.5em 1em;
-	background-color: #2B81AF;
 	color: #FFF;
+	background-color: #2B81AF;
 	text-shadow: rgba(0, 0, 0, 0.5) 2px 2px 1px;
 }
 
@@ -305,14 +305,14 @@
 }
 
 #qunit-tests del {
-	background-color: #E0F2BE;
 	color: #374E0C;
+	background-color: #E0F2BE;
 	text-decoration: none;
 }
 
 #qunit-tests ins {
-	background-color: #FFCACA;
 	color: #500;
+	background-color: #FFCACA;
 	text-decoration: none;
 }
 

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -27,7 +27,7 @@
 }
 
 
-/** Header */
+/** Header (excluding toolbar) */
 
 #qunit-header {
 	padding: 0.5em 0 0.5em 1em;
@@ -52,20 +52,8 @@
 	color: #FFF;
 }
 
-#qunit-testrunner-toolbar label {
-	display: inline-block;
-	padding: 0 0.5em 0 0.1em;
-}
-
 #qunit-banner {
 	height: 5px;
-}
-
-#qunit-testrunner-toolbar {
-	padding: 0.5em 1em 0.5em 1em;
-	color: #5E740B;
-	background-color: #EEE;
-	overflow: hidden;
 }
 
 #qunit-filteredTest {
@@ -81,39 +69,119 @@
 	text-shadow: rgba(0, 0, 0, 0.5) 2px 2px 1px;
 }
 
-#qunit-modulefilter-container {
-	float: right;
-	padding: 0.2em;
+
+/** Toolbar */
+
+#qunit-testrunner-toolbar {
+	padding: 0.5em 1em 0.5em 1em;
+	color: #5E740B;
+	background-color: #EEE;
 }
 
-#qunit-modulefilter-component {
-	width: 400px;
+#qunit-testrunner-toolbar .clearfix {
+	height: 0;
+	clear: both;
+}
+
+#qunit-testrunner-toolbar label {
 	display: inline-block;
 }
 
-#qunit-modulefilter-search {
-	width: inherit;
-	box-sizing: border-box;
+#qunit-testrunner-toolbar input[type=checkbox],
+#qunit-testrunner-toolbar input[type=radio] {
+	margin: 3px;
+	vertical-align: -2px;
 }
 
-#qunit-modulefilter-dropdown-container {
-	color: #000000;
+#qunit-testrunner-toolbar input[type=text] {
+	box-sizing: border-box;
+	height: 1.6em;
+}
+
+.qunit-url-config,
+.qunit-filter,
+#qunit-modulefilter {
+	display: inline-block;
+	line-height: 2.1em;
+}
+
+.qunit-filter,
+#qunit-modulefilter {
+	float: right;
+	position: relative;
+	margin-left: 1em;
+}
+
+.qunit-url-config label {
+	margin-right: 0.5em;
+}
+
+#qunit-modulefilter-search {
+	box-sizing: border-box;
+	width: 400px;
+}
+
+#qunit-modulefilter-search-container:after {
 	position: absolute;
-	width: inherit;
+	right: 0.3em;
+	content: "\25bc";
+	color: black;
+}
+
+#qunit-modulefilter-dropdown {
+	/* align with #qunit-modulefilter-search */
+	box-sizing: border-box;
+	width: 400px;
+	position: absolute;
+	right: 0;
+	top: 50%;
+	margin-top: 0.8em;
+
 	border: 1px solid #D3D3D3;
 	border-top: none;
-	box-sizing: border-box;
-	background-color: #F5F5F5;
 	border-radius: 0 0 .25em .25em;
-	font-family: sans-serif;
-	font-size: smaller;
+	color: #000;
+	background-color: #F5F5F5;
+	z-index: 99;
+}
+
+#qunit-modulefilter-dropdown a {
+	color: inherit;
+	text-decoration: none;
+}
+
+#qunit-modulefilter-dropdown label.checked {
+	font-weight: bold;
+	color: #000;
+	background-color: #D2E0E6;
+}
+
+#qunit-modulefilter-dropdown label:hover {
+	color: #FFF;
+	background-color: #0D3349;
+}
+
+#qunit-modulefilter-clear {
+	display: block;
+
+	/* align with #qunit-modulefilter-dropdown-list */
+	padding: 0.4em 0 0.4em;
+	padding-left: 0.15em;
+	font: smaller/1.5em sans-serif;
+}
+
+#qunit-modulefilter-clear > :first-child {
+	/* insert padding to align with checkbox margins */
+	padding-left: 3px;
 }
 
 #qunit-modulefilter-dropdown-list {
 	max-height: 200px;
 	overflow-y: auto;
-	padding: 0;
-	margin: 0 .15em .15em .15em;
+	margin: 0;
+	border-top: 2px groove threedhighlight;
+	padding: 0.4em 0 0;
+	font: smaller/1.5em sans-serif;
 }
 
 #qunit-modulefilter-dropdown-list li {
@@ -122,38 +190,11 @@
 	text-overflow: ellipsis;
 }
 
-
 #qunit-modulefilter-dropdown-list label {
-	display: inline;
-}
-
-#qunit-modulefilter-dropdown-list input[type="checkbox"] {
-	position: relative;
-	top: 0;
-	margin-right: .5em;
-}
-
-#clear-module-filter {
-	cursor: pointer;
-	display: inline-block;
-	width: 100%;
-	margin-top: .5em;
-}
-
-#clear-module-filter-text {
-	margin-left: .8em;
-}
-
-.qunit-url-config {
-	display: inline-block;
-	padding: 0.1em;
-}
-
-.qunit-filter {
 	display: block;
-	float: right;
-	margin-left: 1em;
+	padding-left: 0.15em;
 }
+
 
 /** Tests: Pass/Fail */
 

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -150,27 +150,31 @@
 	text-decoration: none;
 }
 
-#qunit-modulefilter-dropdown label.checked {
+#qunit-modulefilter-dropdown .clickable.checked {
 	font-weight: bold;
 	color: #000;
 	background-color: #D2E0E6;
 }
 
-#qunit-modulefilter-dropdown label:hover {
+#qunit-modulefilter-dropdown .clickable:hover {
 	color: #FFF;
 	background-color: #0D3349;
 }
 
-#qunit-modulefilter-clear {
-	display: block;
+#qunit-modulefilter-actions {
+	display: table;
+	width: 100%;
 
 	/* align with #qunit-modulefilter-dropdown-list */
-	padding: 0.4em 0 0.4em;
-	padding-left: 0.15em;
 	font: smaller/1.5em sans-serif;
 }
 
-#qunit-modulefilter-clear > :first-child {
+#qunit-modulefilter-actions > * {
+	display: table-cell;
+	padding: 0.4em 0;
+}
+
+#qunit-modulefilter-actions > :first-child {
 	/* insert padding to align with checkbox margins */
 	padding-left: 3px;
 }
@@ -190,7 +194,7 @@
 	text-overflow: ellipsis;
 }
 
-#qunit-modulefilter-dropdown-list label {
+#qunit-modulefilter-dropdown-list .clickable {
 	display: block;
 	padding-left: 0.15em;
 }

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -162,19 +162,26 @@
 }
 
 #qunit-modulefilter-actions {
-	display: table;
-	width: 100%;
+	display: block;
+	overflow: auto;
 
 	/* align with #qunit-modulefilter-dropdown-list */
 	font: smaller/1.5em sans-serif;
 }
 
 #qunit-modulefilter-dropdown #qunit-modulefilter-actions > * {
-	display: table-cell;
-	padding: 0.4em 0;
+	box-sizing: border-box;
+	max-height: 2.8em;
+	display: block;
+	padding: 0.4em;
 }
 
-#qunit-modulefilter-dropdown #qunit-modulefilter-actions > :first-child {
+#qunit-modulefilter-dropdown #qunit-modulefilter-actions > button {
+	float: right;
+	font: inherit;
+}
+
+#qunit-modulefilter-dropdown #qunit-modulefilter-actions > :last-child {
 	/* insert padding to align with checkbox margins */
 	padding-left: 3px;
 }


### PR DESCRIPTION
Fixes gh-988
Ref 0780127

Updates styles, enlarges interaction targets (i.e., `display:block`), adds a down-arrow and Reset/Apply buttons in the module picker, displays current module section (comma-separated) in placeholder and tooltip text, and closes the drop-down on Escape keydown. Possible more as well, but those are the key changes.
![screenshot](https://cloud.githubusercontent.com/assets/1199584/14665929/85742698-06a4-11e6-9a98-f235c5c8f094.png)