### PR TITLE
Dump: update typeOf to extract extra complex type definition

### DIFF
--- a/src/dump.js
+++ b/src/dump.js
@@ -35,6 +35,19 @@ QUnit.dump = ( function() {
 		return join( "[", ret, "]" );
 	}
 
+	function isArray( obj ) {
+		return (
+
+			//Native Arrays
+		toString.call( obj ) === "[object Array]" ||
+
+		// NodeList objects
+		( typeof obj.length === "number" && obj.item !== undefined ) &&
+		( obj.length ?
+		obj.item( 0 ) === obj[ 0 ] :
+			( obj.item( 0 ) === null && obj[ 0 ] === undefined ) ) );
+	}
+
 	var reName = /^function (\w+)/,
 		dump = {
 
@@ -63,19 +76,6 @@ QUnit.dump = ( function() {
 			typeOf: function( obj ) {
 				var type;
 
-				function isArray() {
-					return (
-
-						//Native Arrays
-						toString.call( obj ) === "[object Array]" ||
-
-						// NodeList objects
-						( typeof obj.length === "number" && obj.item !== undefined ) &&
-							( obj.length ?
-								obj.item( 0 ) === obj[ 0 ] :
-								( obj.item( 0 ) === null &&	obj[ 0 ] === undefined ) ) );
-				}
-
 				if ( obj === null ) {
 					type = "null";
 				} else if ( typeof obj === "undefined" ) {
@@ -94,7 +94,7 @@ QUnit.dump = ( function() {
 					type = "document";
 				} else if ( obj.nodeType ) {
 					type = "node";
-				} else if ( isArray() ) {
+				} else if ( isArray( obj ) ) {
 					type = "array";
 				} else if ( obj.constructor === Error.prototype.constructor ) {
 					type = "error";

--- a/src/dump.js
+++ b/src/dump.js
@@ -62,6 +62,20 @@ QUnit.dump = ( function() {
 			},
 			typeOf: function( obj ) {
 				var type;
+
+				function isArray() {
+					return (
+
+						//Native Arrays
+						toString.call( obj ) === "[object Array]" ||
+
+						// NodeList objects
+						( typeof obj.length === "number" && obj.item !== undefined ) &&
+							( obj.length ?
+								obj.item( 0 ) === obj[ 0 ] :
+								( obj.item( 0 ) === null &&	obj[ 0 ] === undefined ) ) );
+				}
+
 				if ( obj === null ) {
 					type = "null";
 				} else if ( typeof obj === "undefined" ) {
@@ -80,16 +94,7 @@ QUnit.dump = ( function() {
 					type = "document";
 				} else if ( obj.nodeType ) {
 					type = "node";
-				} else if (
-
-					// Native arrays
-					toString.call( obj ) === "[object Array]" ||
-
-					// NodeList objects
-					( typeof obj.length === "number" && obj.item !== undefined &&
-					( obj.length ? obj.item( 0 ) === obj[ 0 ] : ( obj.item( 0 ) === null &&
-					obj[ 0 ] === undefined ) ) )
-				) {
+				} else if ( isArray() ) {
 					type = "array";
 				} else if ( obj.constructor === Error.prototype.constructor ) {
 					type = "error";


### PR DESCRIPTION
Older versions of Rhino seem to have an issue with the complexity of the conditional.
Pulling it out into it's own function helps, and also makes the code intent more readable.
