### PR TITLE
Component:  Assert.push

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -51,6 +51,7 @@ QUnit.assert = Assert.prototype = {
 	// Exports test.push() to the user API
 	// Alias of pushResult.
 	push: function( result, actual, expected, message, negative ) {
+		console.log("Warning: assert.push is deprecated, assert.pushResult should be used instead");
 		var currentAssert = this instanceof Assert ? this : QUnit.config.current.assert;
 		return currentAssert.pushResult( {
 			result: result,

--- a/test/main/assert.js
+++ b/test/main/assert.js
@@ -394,3 +394,7 @@ QUnit.test( "throws", function( assert ) {
 		"throws fail when regexp doesn't match the error message"
 	);
 } );
+
+QUnit.test("push", function( assert ) {
+	assert.push( null );
+} );


### PR DESCRIPTION
This prints a message to the console stating that this function is now
deprecated, and pushResult is preferred.

Fixes #986 