### PR TITLE
Tests: Test on all Node.js releases supported by upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 sudo: false
 language: node_js
 node_js:
+  - "0.10"
+  - "0.12"
   - "4"
+  - "6"
 env:
   - NPM_SCRIPT=ci
-  - NPM_SCRIPT=browserstack
 matrix:
   fast_finish: true
   allow_failures:
     - env: NPM_SCRIPT=browserstack
+  include:
+    - node_js: "6"
+      env: NPM_SCRIPT=browserstack
 before_install:
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19VU0VSTkFNRT1icm93c2Vyc3RhY2txdW5pMQo=`
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19LRVk9SllzeHJrVWk5aGJGVndkdW44ZUsK=`


### PR DESCRIPTION
The browserstack job is run only on Node.js 6. Upstream support for Node.js 5
ends in about a month so I didn't add it.