### PR TITLE
All: Prevent async tests from having multiple resume timeouts

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -44,7 +44,7 @@ QUnit.assert = Assert.prototype = {
 
 			test.semaphore -= 1;
 			popped = true;
-			resumeProcessing();
+			resumeProcessing( test );
 		};
 	},
 

--- a/src/core.js
+++ b/src/core.js
@@ -229,25 +229,22 @@ function resumeProcessing( test ) {
 
 	// A slight delay to allow this iteration of the event loop to finish (more assertions, etc.)
 	if ( defined.setTimeout ) {
-		if ( test && test.resuming ) {
-			return;
-		}
-
-		var resume = setTimeout( function() {
+		setTimeout( function() {
 			var current = test || config.current;
-			if ( current && current.semaphore > 0 ) {
+			if ( current && ( current.semaphore > 0 || current.resumed ) ) {
 				return;
 			}
+
 			if ( config.timeout ) {
 				clearTimeout( config.timeout );
 			}
 
+			if ( current ) {
+				current.resumed = true;
+			}
+
 			begin();
 		}, 13 );
-
-		if ( test ) {
-			test.resuming = resume;
-		}
 	} else {
 		begin();
 	}

--- a/src/core.js
+++ b/src/core.js
@@ -229,7 +229,11 @@ function resumeProcessing( test ) {
 
 	// A slight delay to allow this iteration of the event loop to finish (more assertions, etc.)
 	if ( defined.setTimeout ) {
-		setTimeout( function() {
+		if ( test && test.resuming ) {
+			return;
+		}
+
+		var resume = setTimeout( function() {
 			var current = test || config.current;
 			if ( current && current.semaphore > 0 ) {
 				return;
@@ -240,6 +244,10 @@ function resumeProcessing( test ) {
 
 			begin();
 		}, 13 );
+
+		if ( test ) {
+			test.resuming = resume;
+		}
 	} else {
 		begin();
 	}

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -82,7 +82,7 @@ QUnit.test( "parallel calls of differing speeds", function( assert ) {
 	setTimeout( function() {
 		assert.ok( true );
 		done2();
-	}, 100);
+	}, 100 );
 } );
 
 QUnit.test( "waterfall calls", function( assert ) {

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -70,6 +70,21 @@ QUnit.test( "parallel calls", function( assert ) {
 	} );
 } );
 
+QUnit.test( "parallel calls of differing speeds", function( assert ) {
+	var done1 = assert.async(),
+		done2 = assert.async();
+
+	assert.expect( 2 );
+	setTimeout( function() {
+		assert.ok( true );
+		done1();
+	} );
+	setTimeout( function() {
+		assert.ok( true );
+		done2();
+	}, 100);
+} );
+
 QUnit.test( "waterfall calls", function( assert ) {
 	var done2,
 		done1 = assert.async();


### PR DESCRIPTION
Addressing #984.

The root issue is that it was possible for a single async test to have multiple `resumeProcessing` timeouts. [This parallel assert.async calls test](https://github.com/jquery/qunit/blob/master/test/main/async.js#L58-L71) is probably the easiest case to see why that would be a problem.

1. `done1` would get called and queue up a `resumeProcessing` timeout.
2. `done2` would get called and queue up another `resumeProcessing` timeout. `test.semaphore` is now at `0`.
3. The first timeout executes and hits `begin()` to resume the test suite
4. The second timeout executes and hits `begin()` as well, which causes issues because we're already running

The reason this worked without passing in `test` before is that `config.current` would update between the time 3 and 4 happened above which would prevent `begin()` from getting called a second time.

My solution is to check to see if `test` is already waiting to resume when passed into `resumeProcessing`.