### PR TITLE
Tests: Fix script src for stack-errors test

### DIFF
--- a/test/stack-errors.html
+++ b/test/stack-errors.html
@@ -5,7 +5,7 @@
 	<title>QUnit Main Test Suite</title>
 	<link rel="stylesheet" href="../dist/qunit.css">
 	<script src="../dist/qunit.js"></script>
-	<script src="stack.js"></script>
+	<script src="stack-errors.js"></script>
 </head>
 <body>
 	<div id="qunit"></div>


### PR DESCRIPTION
Fixed the bad reference, but the test still seems pretty broken.

* The `globals` test reports "Introduced global variable(s): external, chrome, document, test, module, expect, start, ok, notOk, equal, notEqual, propEqual, notPropEqual, deepEqual, notDeepEqual, strictEqual, notStrictEqual, throws, raises, QUnit, polluteGlobal, speechSynthesis, caches, ondeviceorientationabsolute, localStorage, sessionStorage, webkitStorageInfo, indexedDB, webkitIndexedDB, ondeviceorientation, ondevicemotion, crypto, postMessage, blur, focus, [...]" and many more.
* There's plenty false negatives (I think), like "Uncaught Error: pushFailure() assertion outside test contex" 

And apparently the whole test suite isn't run as party of `npm test`, so the very basic issue of a bad file reference went unnoticed until now. As such, maybe the better solution is to delete it?