### PR TITLE
Core: Ensure runtime for skipped tests is 0

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -206,9 +206,11 @@ Test.prototype = {
 		}
 
 		var i,
+			skipped = !!this.skip,
 			bad = 0;
 
 		this.runtime = now() - this.started;
+
 		config.stats.all += this.assertions.length;
 		config.moduleStats.all += this.assertions.length;
 
@@ -224,11 +226,11 @@ Test.prototype = {
 		runLoggingCallbacks( "testDone", {
 			name: this.testName,
 			module: this.module.name,
-			skipped: !!this.skip,
+			skipped: skipped,
 			failed: bad,
 			passed: this.assertions.length - bad,
 			total: this.assertions.length,
-			runtime: this.runtime,
+			runtime: skipped ? 0 : this.runtime,
 
 			// HTML Reporter use
 			assertions: this.assertions,

--- a/test/logs.js
+++ b/test/logs.js
@@ -181,9 +181,6 @@ QUnit.test( module1Test2.name, function( assert ) {
 
 	delete testDoneContext.runtime;
 
-	// DEPRECATED: remove this delete when removing the duration property
-	delete testDoneContext.duration;
-
 	// Delete testDoneContext.assertions so we can easily jump to next assertion
 	delete testDoneContext.assertions;
 
@@ -268,8 +265,6 @@ QUnit.skip( module2Test3.name );
 QUnit.test( module2Test4.name, function( assert ) {
 	assert.expect( 1 );
 
-	delete testDoneContext.runtime;
-	delete testDoneContext.duration;
 	delete testDoneContext.source;
 
 	assert.deepEqual( testDoneContext, {
@@ -280,7 +275,8 @@ QUnit.test( module2Test4.name, function( assert ) {
 		passed: 0,
 		total: 0,
 		skipped: true,
-		testId: module2Test3.testId
+		testId: module2Test3.testId,
+		runtime: 0
 	}, "testDone context" );
 } );
 


### PR DESCRIPTION
Addressing #1004.

This ensures that the `runtime` property during `testDone` logging for skipped tests is alway `0`. I think a future state where we remove the property all together is possible, but since that would be a breaking change I am not inclined to do that at this point in time.

cc @flore77 @jzaefferer @leobalter