### PR TITLE
Dump: Add parser for Symbol

### DIFF
--- a/src/dump.js
+++ b/src/dump.js
@@ -258,7 +258,10 @@ QUnit.dump = ( function() {
 				date: quote,
 				regexp: literal,
 				number: literal,
-				"boolean": literal
+				"boolean": literal,
+				symbol: function( sym ) {
+					return sym.toString();
+				}
 			},
 
 			// If true, entities are escaped ( <, >, \t, space and \n )

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1892,6 +1892,6 @@ QUnit[ hasES6Symbol ? "test" : "skip" ]( "regular checks", function ( assert ) {
 	assert.equal( QUnit.equiv( a, a ), true, "Same symbol is equivalent" );
 	assert.equal(
 		QUnit.equiv( a, b ), false,
-		"Not equivalent to another similar symbol built build on the same token"
+		"Not equivalent to another similar symbol built on the same token"
 	);
 } );

--- a/test/main/dump.js
+++ b/test/main/dump.js
@@ -1,3 +1,5 @@
+/* globals Symbol:false */
+
 QUnit.module( "dump", {
 	afterEach: function() {
 		QUnit.dump.maxDepth = null;
@@ -16,6 +18,11 @@ QUnit.test( "dump output", function( assert ) {
 			QUnit.dump.parse( document.getElementsByTagName( "h1" ) ),
 			"[\n  <h1 id=\"qunit-header\"></h1>\n]"
 		);
+	}
+
+	if ( typeof Symbol === "function" ) {
+		var sym = Symbol( "QUnit" );
+		assert.equal( QUnit.dump.parse( sym ), "Symbol(QUnit)", "parse is correct for symbols" );
 	}
 } );
 


### PR DESCRIPTION
Addressing #1008. The root issue is that `dump.parse` didn't have a parser defined for object's of type `symbol` and thus it didn't return a `string`. This fixes that and adds a test to catch regressions.

Here are some examples of the fix in action. The first test is essentially `Symbol("QUnit") === Symbol("QUnit")` and the test shows `Symbol("QUnit1") === Symbol("QUnit2")`.

![screen shot 2016-06-24 at 9 28 48 pm](https://cloud.githubusercontent.com/assets/3526753/16354720/03b53e34-3a53-11e6-874f-38c480d68c6f.png)
