### PR TITLE
Core: Improve internal async handling by removing resumed

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -26,6 +26,7 @@ QUnit.assert = Assert.prototype = {
 			acceptCallCount = 1;
 		}
 
+		test.asyncCallCount += acceptCallCount;
 		test.semaphore += 1;
 		test.usedAsync = true;
 		pauseProcessing( test );
@@ -37,13 +38,21 @@ QUnit.assert = Assert.prototype = {
 					sourceFromStacktrace( 2 ) );
 				return;
 			}
+
 			acceptCallCount -= 1;
+			test.asyncCallCount -= 1;
+
 			if ( acceptCallCount > 0 ) {
 				return;
 			}
 
 			test.semaphore -= 1;
 			popped = true;
+
+			if ( test.asyncCallCount > 0 ) {
+				return;
+			}
+
 			resumeProcessing( test );
 		};
 	},

--- a/src/core.js
+++ b/src/core.js
@@ -230,17 +230,21 @@ function resumeProcessing( test ) {
 	// A slight delay to allow this iteration of the event loop to finish (more assertions, etc.)
 	if ( defined.setTimeout ) {
 		setTimeout( function() {
-			var current = test || config.current;
-			if ( current && ( current.semaphore > 0 || current.resumed ) ) {
+			var current;
+
+			// Ensure we are resuming the current test
+			if ( test && test === config.current ) {
+				current = test;
+			} else {
+				current = config.current;
+			}
+
+			if ( current && ( current.semaphore > 0 ) ) {
 				return;
 			}
 
 			if ( config.timeout ) {
 				clearTimeout( config.timeout );
-			}
-
-			if ( current ) {
-				current.resumed = true;
 			}
 
 			begin();

--- a/src/test.js
+++ b/src/test.js
@@ -12,6 +12,7 @@ function Test( settings ) {
 	this.assertions = [];
 	this.semaphore = 0;
 	this.usedAsync = false;
+	this.asyncCallCount = 0;
 	this.module = config.currentModule;
 	this.stack = sourceFromStacktrace( 3 );
 

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -20,6 +20,14 @@ function _setupForFailingAssertionsAfterAsyncDone( assert ) {
 	};
 }
 
+function asyncCallback( assert ) {
+	var done = assert.async();
+	setTimeout( function() {
+		assert.ok( true );
+		done();
+	} );
+}
+
 QUnit.module( "assert.async" );
 
 QUnit.test( "single call", function( assert ) {
@@ -101,6 +109,22 @@ QUnit.test( "waterfall calls", function( assert ) {
 	} );
 } );
 
+QUnit.test( "waterfall calls of differing speeds", function( assert ) {
+	var done2,
+		done1 = assert.async();
+
+	assert.expect( 2 );
+	setTimeout( function() {
+		assert.ok( true, "first" );
+		done1();
+		done2 = assert.async();
+		setTimeout( function() {
+			assert.ok( true, "second" );
+			done2();
+		}, 100 );
+	} );
+} );
+
 QUnit.test( "fails if callback is called more than once in test", function( assert ) {
 
 	// Having an outer async flow in this test avoids the need to manually modify QUnit internals
@@ -147,7 +171,18 @@ QUnit.test( "fails if callback is called more than callback call count", functio
 	}, new RegExp( "Too many calls to the `assert.async` callback" ) );
 
 	done();
+} );
 
+QUnit.module( "assert.async in module hooks", {
+	before: asyncCallback,
+	beforeEach: asyncCallback,
+	afterEach: asyncCallback,
+	after: asyncCallback
+} );
+
+QUnit.test( "calls in all hooks", function( assert ) {
+	assert.expect( 5 );
+	asyncCallback( assert );
 } );
 
 QUnit.module( "assert.async fails if callback is called more than once in", {

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -106,6 +106,26 @@ QUnit.test( "fulfilled Promise", function( assert ) {
 	assert.expect( 1 );
 } );
 
+QUnit.module( "Module with Promise-aware everything", {
+	before: function( assert ) {
+		return createMockPromise( assert );
+	},
+	beforeEach: function( assert ) {
+		return createMockPromise( assert );
+	},
+	afterEach: function( assert ) {
+		return createMockPromise( assert );
+	},
+	after: function( assert ) {
+		return createMockPromise( assert );
+	}
+} );
+
+QUnit.test( "fullfilled Promise", function( assert ) {
+	assert.expect( 5 );
+	return createMockPromise( assert );
+} );
+
 QUnit.module( "Promise-aware return values without beforeEach/afterEach" );
 
 QUnit.test( "non-Promise", function( assert ) {


### PR DESCRIPTION
The fixes introduced in #1002 actually wound up also causing a regression in #1016 & #1018.

After digging into it for a while, I think the solution shipped in #1002 was actually the wrong approach to take. It worked for simple cases, but for tests with multiple async hooks (as reported in #1016) it was too brittle due to race conditions of having multiple timeouts for resuming.

This approach, prevents multiple timeouts from being triggered by managing the number of async callbacks within the test. There is still the possibility of some resumes leaking when doing "waterfall" calls, but this can be worked around by simply making sure we're resuming the current test.

I added several test cases to ensure this is more robust.