### PR TITLE
Core: Improve internal async handling

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -26,7 +26,6 @@ QUnit.assert = Assert.prototype = {
 			acceptCallCount = 1;
 		}
 
-		test.asyncCallCount += acceptCallCount;
 		test.semaphore += 1;
 		test.usedAsync = true;
 		pauseProcessing( test );
@@ -38,21 +37,13 @@ QUnit.assert = Assert.prototype = {
 					sourceFromStacktrace( 2 ) );
 				return;
 			}
-
 			acceptCallCount -= 1;
-			test.asyncCallCount -= 1;
-
 			if ( acceptCallCount > 0 ) {
 				return;
 			}
 
 			test.semaphore -= 1;
 			popped = true;
-
-			if ( test.asyncCallCount > 0 ) {
-				return;
-			}
-
 			resumeProcessing( test );
 		};
 	},

--- a/src/assert.js
+++ b/src/assert.js
@@ -17,7 +17,8 @@ QUnit.assert = Assert.prototype = {
 
 	// Put a hold on processing and return a function that will release it a maximum of once.
 	async: function( count ) {
-		var test = this.test,
+		var resume,
+			test = this.test,
 			popped = false,
 			acceptCallCount = count;
 
@@ -26,7 +27,7 @@ QUnit.assert = Assert.prototype = {
 		}
 
 		test.usedAsync = true;
-		internalStop( test );
+		resume = internalStop( test );
 
 		return function done() {
 
@@ -41,7 +42,7 @@ QUnit.assert = Assert.prototype = {
 			}
 
 			popped = true;
-			internalStart( test );
+			resume();
 		};
 	},
 

--- a/src/assert.js
+++ b/src/assert.js
@@ -26,6 +26,7 @@ QUnit.assert = Assert.prototype = {
 			acceptCallCount = 1;
 		}
 
+		test.asyncCallCount += acceptCallCount;
 		test.semaphore += 1;
 		test.usedAsync = true;
 		pauseProcessing( test );
@@ -37,13 +38,21 @@ QUnit.assert = Assert.prototype = {
 					sourceFromStacktrace( 2 ) );
 				return;
 			}
+
 			acceptCallCount -= 1;
+			test.asyncCallCount -= 1;
+
 			if ( acceptCallCount > 0 ) {
 				return;
 			}
 
 			test.semaphore -= 1;
 			popped = true;
+
+			if ( test.asyncCallCount > 0 ) {
+				return;
+			}
+
 			resumeProcessing( test );
 		};
 	},

--- a/src/assert.js
+++ b/src/assert.js
@@ -15,8 +15,7 @@ QUnit.assert = Assert.prototype = {
 		}
 	},
 
-	// Increment this Test's semaphore counter, then return a function that
-	// decrements that counter a maximum of once.
+	// Put a hold on processing and return a function that will release it a maximum of once.
 	async: function( count ) {
 		var test = this.test,
 			popped = false,
@@ -26,9 +25,8 @@ QUnit.assert = Assert.prototype = {
 			acceptCallCount = 1;
 		}
 
-		test.semaphore += 1;
 		test.usedAsync = true;
-		pauseProcessing( test );
+		internalStop( test );
 
 		return function done() {
 
@@ -42,9 +40,8 @@ QUnit.assert = Assert.prototype = {
 				return;
 			}
 
-			test.semaphore -= 1;
 			popped = true;
-			resumeProcessing( test );
+			internalStart( test );
 		};
 	},
 

--- a/src/core.js
+++ b/src/core.js
@@ -135,10 +135,12 @@ extend( QUnit, {
 			filter: ""
 		}, true );
 
-		config.blocking = false;
+		if ( !runStarted ) {
+			config.blocking = false;
 
-		if ( config.autostart ) {
-			scheduleBegin();
+			if ( config.autostart ) {
+				scheduleBegin();
+			}
 		}
 	},
 

--- a/src/core.js
+++ b/src/core.js
@@ -225,40 +225,6 @@ function process( last ) {
 	}
 }
 
-function pauseProcessing( test ) {
-	config.blocking = true;
-
-	if ( config.testTimeout && defined.setTimeout ) {
-		clearTimeout( config.timeout );
-		config.timeout = setTimeout( function() {
-			test.semaphore = 0;
-			QUnit.pushFailure( "Test timed out", sourceFromStacktrace( 2 ) );
-			resumeProcessing( test );
-		}, config.testTimeout );
-	}
-}
-
-function resumeProcessing( test ) {
-
-	// A slight delay to allow this iteration of the event loop to finish (more assertions, etc.)
-	if ( defined.setTimeout ) {
-		setTimeout( function() {
-			if ( test.semaphore > 0 || test.resumed ) {
-				return;
-			}
-			test.resumed = true;
-
-			if ( config.timeout ) {
-				clearTimeout( config.timeout );
-			}
-
-			begin();
-		}, 13 );
-	} else {
-		begin();
-	}
-}
-
 function done() {
 	var runtime, passed;
 

--- a/src/core.js
+++ b/src/core.js
@@ -111,7 +111,7 @@ extend( QUnit, {
 			);
 		}
 
-		resumeProcessing();
+		scheduleBegin();
 	},
 
 	config: config,
@@ -138,7 +138,7 @@ extend( QUnit, {
 		config.blocking = false;
 
 		if ( config.autostart ) {
-			resumeProcessing();
+			scheduleBegin();
 		}
 	},
 
@@ -149,6 +149,20 @@ extend( QUnit, {
 } );
 
 registerLoggingCallbacks( QUnit );
+
+function scheduleBegin() {
+
+	runStarted = true;
+
+	// Add a slight delay to allow definition of more modules and tests.
+	if ( defined.setTimeout ) {
+		setTimeout( function() {
+			begin();
+		}, 13 );
+	} else {
+		begin();
+	}
+}
 
 function begin() {
 	var i, l,
@@ -225,22 +239,17 @@ function pauseProcessing( test ) {
 }
 
 function resumeProcessing( test ) {
-	runStarted = true;
 
 	// A slight delay to allow this iteration of the event loop to finish (more assertions, etc.)
 	if ( defined.setTimeout ) {
 		setTimeout( function() {
-			var current = test || config.current;
-			if ( current && ( current.semaphore > 0 || current.resumed ) ) {
+			if ( test.semaphore > 0 || test.resumed ) {
 				return;
 			}
+			test.resumed = true;
 
 			if ( config.timeout ) {
 				clearTimeout( config.timeout );
-			}
-
-			if ( current ) {
-				current.resumed = true;
 			}
 
 			begin();

--- a/src/core.js
+++ b/src/core.js
@@ -230,21 +230,17 @@ function resumeProcessing( test ) {
 	// A slight delay to allow this iteration of the event loop to finish (more assertions, etc.)
 	if ( defined.setTimeout ) {
 		setTimeout( function() {
-			var current;
-
-			// Ensure we are resuming the current test
-			if ( test && test === config.current ) {
-				current = test;
-			} else {
-				current = config.current;
-			}
-
-			if ( current && ( current.semaphore > 0 ) ) {
+			var current = test || config.current;
+			if ( current && ( current.semaphore > 0 || current.resumed ) ) {
 				return;
 			}
 
 			if ( config.timeout ) {
 				clearTimeout( config.timeout );
+			}
+
+			if ( current ) {
+				current.resumed = true;
 			}
 
 			begin();

--- a/src/core.js
+++ b/src/core.js
@@ -230,17 +230,21 @@ function resumeProcessing( test ) {
 	// A slight delay to allow this iteration of the event loop to finish (more assertions, etc.)
 	if ( defined.setTimeout ) {
 		setTimeout( function() {
-			var current = test || config.current;
-			if ( current && ( current.semaphore > 0 || current.resumed ) ) {
+			var current;
+
+			// Ensure we are resuming the current test
+			if ( test && test === config.current ) {
+				current = test;
+			} else {
+				current = config.current;
+			}
+
+			if ( current && ( current.semaphore > 0 ) ) {
 				return;
 			}
 
 			if ( config.timeout ) {
 				clearTimeout( config.timeout );
-			}
-
-			if ( current ) {
-				current.resumed = true;
 			}
 
 			begin();

--- a/src/test.js
+++ b/src/test.js
@@ -12,6 +12,7 @@ function Test( settings ) {
 	this.assertions = [];
 	this.semaphore = 0;
 	this.usedAsync = false;
+	this.asyncCallCount = 0;
 	this.module = config.currentModule;
 	this.stack = sourceFromStacktrace( 3 );
 

--- a/src/test.js
+++ b/src/test.js
@@ -100,10 +100,6 @@ Test.prototype = {
 
 		config.current = this;
 
-		if ( this.async ) {
-			internalStop( this );
-		}
-
 		this.callbackStarted = now();
 
 		if ( config.notrycatch ) {

--- a/src/test.js
+++ b/src/test.js
@@ -12,7 +12,6 @@ function Test( settings ) {
 	this.assertions = [];
 	this.semaphore = 0;
 	this.usedAsync = false;
-	this.asyncCallCount = 0;
 	this.module = config.currentModule;
 	this.stack = sourceFromStacktrace( 3 );
 

--- a/src/test.js
+++ b/src/test.js
@@ -687,11 +687,13 @@ function internalStart( test ) {
 
 	// Add a slight delay to allow more assertions etc.
 	if ( defined.setTimeout ) {
-		setTimeout( function() {
-			if ( test.semaphore > 0 || test.resumed ) {
+		if ( config.timeout ) {
+			clearTimeout( config.timeout );
+		}
+		config.timeout = setTimeout( function() {
+			if ( test.semaphore > 0 ) {
 				return;
 			}
-			test.resumed = true;
 
 			if ( config.timeout ) {
 				clearTimeout( config.timeout );

--- a/src/test.js
+++ b/src/test.js
@@ -627,16 +627,12 @@ function only( testName, callback ) {
 }
 
 function internalStop( test ) {
-
-	// If a test is running, adjust its semaphore
 	test.semaphore += 1;
 
 	pauseProcessing( test );
 }
 
 function internalStart( test ) {
-
-	// If a test is running, adjust its semaphore
 	test.semaphore -= 1;
 
 	// If semaphore is non-numeric, throw error

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -20,6 +20,14 @@ function _setupForFailingAssertionsAfterAsyncDone( assert ) {
 	};
 }
 
+function asyncCallback( assert ) {
+	var done = assert.async();
+	setTimeout( function() {
+		assert.ok( true );
+		done();
+	} );
+}
+
 QUnit.module( "assert.async" );
 
 QUnit.test( "single call", function( assert ) {
@@ -101,6 +109,22 @@ QUnit.test( "waterfall calls", function( assert ) {
 	} );
 } );
 
+QUnit.test( "waterfall calls of differing speeds", function( assert ) {
+	var done2,
+		done1 = assert.async();
+
+	assert.expect( 2 );
+	setTimeout( function() {
+		assert.ok( true, "first" );
+		done1();
+		done2 = assert.async();
+		setTimeout( function() {
+			assert.ok( true, "second" );
+			done2();
+		}, 100 );
+	} );
+} );
+
 QUnit.test( "fails if callback is called more than once in test", function( assert ) {
 
 	// Having an outer async flow in this test avoids the need to manually modify QUnit internals
@@ -147,7 +171,18 @@ QUnit.test( "fails if callback is called more than callback call count", functio
 	}, new RegExp( "Too many calls to the `assert.async` callback" ) );
 
 	done();
+} );
 
+QUnit.module( "assert.async in module hooks", {
+	before: asyncCallback,
+	beforeEach: asyncCallback,
+	afterEach: asyncCallback,
+	after: asyncCallback
+} );
+
+QUnit.test( "calls in all hooks", function( assert ) {
+	assert.expect( 5 );
+	asyncCallback( assert );
 } );
 
 QUnit.module( "assert.async fails if callback is called more than once in", {

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -106,6 +106,26 @@ QUnit.test( "fulfilled Promise", function( assert ) {
 	assert.expect( 1 );
 } );
 
+QUnit.module( "Module with Promise-aware everything", {
+	before: function( assert ) {
+		return createMockPromise( assert );
+	},
+	beforeEach: function( assert ) {
+		return createMockPromise( assert );
+	},
+	afterEach: function( assert ) {
+		return createMockPromise( assert );
+	},
+	after: function( assert ) {
+		return createMockPromise( assert );
+	}
+} );
+
+QUnit.test( "fullfilled Promise", function( assert ) {
+	assert.expect( 5 );
+	return createMockPromise( assert );
+} );
+
 QUnit.module( "Promise-aware return values without beforeEach/afterEach" );
 
 QUnit.test( "non-Promise", function( assert ) {


### PR DESCRIPTION
Fixes gh-1016
Ref 1f00d5fa3b7064bdecec7b984fe9c15c38df2113

@trentmwillis: Sorry for essentially redoing gh-1017, but investigation of https://github.com/jquery/qunit/pull/1017/files#r69368544 got out of hand and I ended up doing a large chunk of the async cleanup we talked about. Let's call it a half rewrite, but it does resolve gh-1016 without introducing new properties (and in fact still removes `resumed`).