### PR TITLE
Build: Remove dependency on es2015-rollup preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {},
   "devDependencies": {
     "async": "1.5.2",
-    "babel-preset-es2015-rollup": "^1.1.1",
+    "babel-plugin-external-helpers": "6.8.0",
+    "babel-preset-es2015": "6.13.2",
     "browserstack-runner": "0.4.3",
     "commitplease": "2.3.0",
     "grunt": "0.4.5",
@@ -42,11 +43,11 @@
     "grunt-git-authors": "3.1.1",
     "grunt-jscs": "2.8.0",
     "grunt-qunit-istanbul": "0.6.0",
-    "grunt-rollup": "^0.7.1",
+    "grunt-rollup": "0.7.1",
     "grunt-search": "0.1.8",
     "load-grunt-tasks": "3.4.1",
     "requirejs": "2.2.0",
-    "rollup-plugin-babel": "^2.6.1"
+    "rollup-plugin-babel": "2.6.1"
   },
   "scripts": {
     "browserstack": "sh build/run-browserstack.sh",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,12 @@ module.exports = {
 	exports: "none",
 	plugins: [
 		babel( {
-			presets: [ "es2015-rollup" ]
+			presets: [
+
+				// Use ES2015 but don't transpile modules since Rollup does that
+				[ "es2015", { modules: false } ]
+			],
+			plugins: [ "external-helpers" ]
 		} )
 	],
 


### PR DESCRIPTION
This is should fix the build by removing our dependency on the es2015-rollup preset.