### PR TITLE
HTML Reporter: Fix expanding failed tests when collapse is false.

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -816,14 +816,16 @@ QUnit.testDone( function( details ) {
 
 		// Collapse the passing tests
 		addClass( assertList, "qunit-collapsed" );
-	} else if ( bad && config.collapse && !collapseNext ) {
+	} else if ( config.collapse ) {
+		if ( !collapseNext ) {
 
-		// Skip collapsing the first failing test
-		collapseNext = true;
-	} else {
+			// Skip collapsing the first failing test
+			collapseNext = true;
+		} else {
 
-		// Collapse remaining tests
-		addClass( assertList, "qunit-collapsed" );
+			// Collapse remaining tests
+			addClass( assertList, "qunit-collapsed" );
+		}
 	}
 
 	// The testItem.firstChild is the test name


### PR DESCRIPTION
Looks like QUnit.config.collapse = false stopped working with commit 5333de89dda55691e1634081e6fe97033185f836. This fixes that regression.