### PR TITLE
change bower.json license to SPDX format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "qunit/qunit.js",
     "qunit/qunit.css"
   ],
-  "license": "https://github.com/jquery/qunit/blob/master/LICENSE.txt",
+  "license": "MIT",
   "ignore": [
     "**/.*",
     "!LICENSE.txt",


### PR DESCRIPTION
Bower has adopted SPDX format license names, like npm's package.json.
Having a url here confuses some automated tools :).

https://github.com/bower/bower/issues/895

Thanks!