### PR TITLE
Test: Properly handle Promises rejected without an error

### DIFF
--- a/src/core/stacktrace.js
+++ b/src/core/stacktrace.js
@@ -9,7 +9,7 @@ export function extractStacktrace( e, offset ) {
 
 	var stack, include, i;
 
-	if ( e.stack ) {
+	if ( e && e.stack ) {
 		stack = e.stack.split( "\n" );
 		if ( /^error$/i.test( stack[ 0 ] ) ) {
 			stack.shift();

--- a/src/test.js
+++ b/src/test.js
@@ -378,7 +378,8 @@ Test.prototype = {
 					function( error ) {
 						message = "Promise rejected " +
 							( !phase ? "during" : phase.replace( /Each$/, "" ) ) +
-							" " + test.testName + ": " + ( error.message || error );
+							" \"" + test.testName + "\": " +
+							( ( error && error.message ) || error );
 						test.pushFailure( message, extractStacktrace( error, 0 ) );
 
 						// Else next test will carry the responsibility


### PR DESCRIPTION
Fixes #1039. Adds tests for the correct behavior as well.

cc @platinumazure @tbiesemann