### PR TITLE
Test improvements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,7 +43,7 @@ grunt.initConfig( {
 		},
 		all: [
 			"*.js",
-            "reporter/**/*.js",
+			"reporter/**/*.js",
 			"runner/**/*.js",
 			"src/**/*.js",
 
@@ -51,7 +51,7 @@ grunt.initConfig( {
 			"build/*.js",
 			"build/tasks/**/*.js"
 		]
-    },
+	},
 	search: {
 		options: {
 
@@ -86,6 +86,7 @@ grunt.initConfig( {
 			"test/startError.html",
 			"test/reorderError1.html",
 			"test/reorderError2.html",
+			"test/callbacks.html",
 			"test/logs.html",
 			"test/setTimeout.html",
 			"test/amd.html",

--- a/test/callbacks.html
+++ b/test/callbacks.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>QUnit Callbacks Test Suite</title>
+	<link rel="stylesheet" href="../dist/qunit.css">
+	<script src="../dist/qunit.js"></script>
+	<script src="callbacks.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+	<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -1,0 +1,120 @@
+var invokedHooks = [];
+var done = false;
+
+function callback( name ) {
+	return function() {
+		if ( done ) {
+			return;
+		}
+
+		invokedHooks.push( name );
+	};
+}
+
+QUnit.begin( callback( "begin1" ) );
+QUnit.begin( callback( "begin2" ) );
+QUnit.moduleStart( callback( "moduleStart1" ) );
+QUnit.moduleStart( callback( "moduleStart2" ) );
+QUnit.testStart( callback( "testStart1" ) );
+QUnit.testStart( callback( "testStart2" ) );
+
+QUnit.log( callback( "log1" ) );
+QUnit.log( callback( "log2" ) );
+
+QUnit.testDone( callback( "testDone1" ) );
+QUnit.testDone( callback( "testDone2" ) );
+QUnit.moduleDone( callback( "moduleDone1" ) );
+QUnit.moduleDone( callback( "moduleDone2" ) );
+QUnit.done( callback( "done1" ) );
+QUnit.done( callback( "done2" ) );
+
+QUnit.done( function() {
+	if ( done ) {
+		return;
+	}
+
+	done = true;
+
+	QUnit.test( "verify callback order", function( assert ) {
+		assert.deepEqual( invokedHooks, [
+			"begin1",
+			"begin2",
+			"moduleStart1",
+			"moduleStart2",
+			"testStart1",
+			"testStart2",
+			"module1 > before",
+			"module1 > beforeEach",
+			"module1 > test1",
+			"log1",
+			"log2",
+			"module1 > afterEach",
+			"testDone1",
+			"testDone2",
+			"moduleDone1",
+			"moduleDone2",
+			"moduleStart1",
+			"moduleStart2",
+			"testStart1",
+			"testStart2",
+			"module2 > before",
+			"module1 > beforeEach",
+			"module2 > beforeEach",
+			"module2 > test1",
+			"log1",
+			"log2",
+			"module2 > afterEach",
+			"module1 > afterEach",
+			"module2 > after",
+			"testDone1",
+			"testDone2",
+			"moduleDone1",
+			"moduleDone2",
+			"moduleStart1",
+			"moduleStart2",
+			"testStart1",
+			"testStart2",
+			"module1 > beforeEach",
+			"module1 > test2",
+			"log1",
+			"log2",
+			"module1 > afterEach",
+			"module1 > after",
+			"testDone1",
+			"testDone2",
+			"moduleDone1",
+			"moduleDone2",
+			"done1",
+			"done2"
+		] );
+	} );
+} );
+
+QUnit.module( "module1", {
+	before: callback( "module1 > before" ),
+	beforeEach: callback( "module1 > beforeEach" ),
+	afterEach: callback( "module1 > afterEach" ),
+	after: callback( "module1 > after" )
+}, function() {
+	QUnit.test( "test1", function( assert ) {
+		invokedHooks.push( "module1 > test1" );
+		assert.ok( true );
+	} );
+
+	QUnit.module( "module2", {
+		before: callback( "module2 > before" ),
+		beforeEach: callback( "module2 > beforeEach" ),
+		afterEach: callback( "module2 > afterEach" ),
+		after: callback( "module2 > after" )
+	}, function() {
+		QUnit.test( "test1", function( assert ) {
+			invokedHooks.push( "module2 > test1" );
+			assert.ok( true );
+		} );
+	} );
+
+	QUnit.test( "test2", function( assert ) {
+		invokedHooks.push( "module1 > test2" );
+		assert.ok( true );
+	} );
+} );

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -165,6 +165,8 @@ QUnit.module( "Promise-aware return values with rejections", {
 } );
 
 QUnit.test( "rejected Promise with undefined value", function( assert ) {
+	assert.expect( 2 );
+
 	this.pushFailure = assert.test.pushFailure;
 	assert.test.pushFailure = function( message ) {
 		assert.strictEqual(
@@ -172,10 +174,13 @@ QUnit.test( "rejected Promise with undefined value", function( assert ) {
 			"Promise rejected during \"rejected Promise with undefined value\": undefined"
 		);
 	};
+
 	return createMockPromise( assert, true, undefined );
 } );
 
 QUnit.test( "rejected Promise with error value", function( assert ) {
+	assert.expect( 2 );
+
 	this.pushFailure = assert.test.pushFailure;
 	assert.test.pushFailure = function( message ) {
 		assert.strictEqual(
@@ -183,10 +188,13 @@ QUnit.test( "rejected Promise with error value", function( assert ) {
 			"Promise rejected during \"rejected Promise with error value\": this is an error"
 		);
 	};
+
 	return createMockPromise( assert, true, new Error( "this is an error" ) );
 } );
 
 QUnit.test( "rejected Promise with string value", function( assert ) {
+	assert.expect( 2 );
+
 	this.pushFailure = assert.test.pushFailure;
 	assert.test.pushFailure = function( message ) {
 		assert.strictEqual(
@@ -194,5 +202,6 @@ QUnit.test( "rejected Promise with string value", function( assert ) {
 			"Promise rejected during \"rejected Promise with string value\": this is an error"
 		);
 	};
+
 	return createMockPromise( assert, true, "this is an error" );
 } );


### PR DESCRIPTION
This improves some various tests. Most notably it adds tests to verify the order of execution for logging callbacks and module hooks (as raised in https://github.com/jquery/api.qunitjs.com/issues/136).

While writing these tests, 2 questions came up:

1. Should the "done" category of callbacks (`done`, `moduleDone`, and `testDone`) be FIFO or LIFO? I know we had a lot of discussion about a similar topic in #977.
2. Should `moduleDone` fire when starting a nested module? I don't believe it should, since the parent module is not technically finished yet.