### PR TITLE
Core: Improve moduleDone and moduleStart behavior

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -263,16 +263,6 @@ function done() {
 	internalState.autorun = true;
 
 	// Log the last module results
-	if ( config.previousModule ) {
-		runLoggingCallbacks( "moduleDone", {
-			name: config.previousModule.name,
-			tests: config.previousModule.tests,
-			failed: config.moduleStats.bad,
-			passed: config.moduleStats.all - config.moduleStats.bad,
-			total: config.moduleStats.all,
-			runtime: now() - config.moduleStats.started
-		} );
-	}
 	delete config.previousModule;
 
 	runtime = now() - config.started;

--- a/src/core.js
+++ b/src/core.js
@@ -150,7 +150,6 @@ extend( QUnit, {
 		// Initialize the configuration options
 		extend( config, {
 			stats: { all: 0, bad: 0 },
-			moduleStats: { all: 0, bad: 0 },
 			started: 0,
 			updateRate: 1000,
 			autostart: true,
@@ -261,9 +260,6 @@ function done() {
 	var runtime, passed;
 
 	internalState.autorun = true;
-
-	// Log the last module results
-	delete config.previousModule;
 
 	runtime = now() - config.started;
 	passed = config.stats.all - config.stats.bad;

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -43,7 +43,8 @@ const config = {
 	// The first unnamed module
 	currentModule: {
 		name: "",
-		tests: []
+		tests: [],
+		testsRun: 0
 	},
 
 	callbacks: {}

--- a/src/test.js
+++ b/src/test.js
@@ -66,16 +66,6 @@ Test.prototype = {
 				// Without this, reporters can get testStart before moduleStart  which is a problem.
 				!hasOwn.call( config, "previousModule" )
 		) {
-			if ( hasOwn.call( config, "previousModule" ) ) {
-				runLoggingCallbacks( "moduleDone", {
-					name: config.previousModule.name,
-					tests: config.previousModule.tests,
-					failed: config.moduleStats.bad,
-					passed: config.moduleStats.all - config.moduleStats.bad,
-					total: config.moduleStats.all,
-					runtime: now() - config.moduleStats.started
-				} );
-			}
 			config.previousModule = this.module;
 			config.moduleStats = { all: 0, bad: 0, started: now() };
 			runLoggingCallbacks( "moduleStart", {
@@ -213,6 +203,7 @@ Test.prototype = {
 		}
 
 		var i,
+			module = this.module,
 			skipped = !!this.skip,
 			bad = 0;
 
@@ -229,10 +220,10 @@ Test.prototype = {
 			}
 		}
 
-		notifyTestsRan( this.module );
+		notifyTestsRan( module );
 		runLoggingCallbacks( "testDone", {
 			name: this.testName,
-			module: this.module.name,
+			module: module.name,
 			skipped: skipped,
 			failed: bad,
 			passed: this.assertions.length - bad,
@@ -246,6 +237,17 @@ Test.prototype = {
 			// Source of Test
 			source: this.stack
 		} );
+
+		if ( module.testsRun === numberOfTests( module ) ) {
+			runLoggingCallbacks( "moduleDone", {
+				name: module.name,
+				tests: module.tests,
+				failed: config.moduleStats.bad,
+				passed: config.moduleStats.all - config.moduleStats.bad,
+				total: config.moduleStats.all,
+				runtime: now() - config.moduleStats.started
+			} );
+		}
 
 		config.current = undefined;
 	},

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -51,8 +51,6 @@ QUnit.done( function() {
 			"module1 > afterEach",
 			"testDone1",
 			"testDone2",
-			"moduleDone1",
-			"moduleDone2",
 			"moduleStart1",
 			"moduleStart2",
 			"testStart1",

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -68,8 +68,6 @@ QUnit.done( function() {
 			"testDone2",
 			"moduleDone1",
 			"moduleDone2",
-			"moduleStart1",
-			"moduleStart2",
 			"testStart1",
 			"testStart2",
 			"module1 > beforeEach",


### PR DESCRIPTION
Addressing #1044. This ensures that `moduleDone` and `moduleStart` are fired exactly once per module.

Also, removes `config.previousModule` and `config.moduleStats`, these aren't documented anywhere and seem to have just been there to pass information around QUnit internals, so it seems beneficial to get them off the global. @leobalter hope you can verify if it is safe to remove these.

A couple additional things noticed in this cleanup:

* Modules currently have a `childModule` property, this contains a reference to a single module. This likely means that modules with multiple nested children are broken. We should fix that.

* `moduleDone` reports the `runtime` of the module, but this is done by taking a "start" value when `moduleStart` is emitted. This is likely to produce odd and not very useful results when tests within a module are not run serially (e.g., when reordering after a failure or using the `seed` option). We should likely change the `runtime` to be a summation of the individual test run times.

If the above suggestions seem okay, I can make those changes in a separate PR (to prevent this one being too complex).