### PR TITLE
Core: Support multiple nested modules hooks properly

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -77,12 +77,13 @@ extend( QUnit, {
 				parentModule: parentModule,
 				tests: [],
 				moduleId: generateHash( moduleName ),
-				testsRun: 0
+				testsRun: 0,
+				childModules: []
 			};
 
 			var env = {};
 			if ( parentModule ) {
-				parentModule.childModule = module;
+				parentModule.childModules.push( module );
 				extend( env, parentModule.testEnvironment );
 				delete env.beforeEach;
 				delete env.afterEach;

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -44,6 +44,7 @@ const config = {
 	currentModule: {
 		name: "",
 		tests: [],
+		childModules: [],
 		testsRun: 0
 	},
 

--- a/src/test.js
+++ b/src/test.js
@@ -733,10 +733,16 @@ function internalStart( test ) {
 }
 
 function numberOfTests( module ) {
-	var count = module.tests.length;
-	while ( ( module = module.childModule ) ) {
-		count += module.tests.length;
+	let count = module.tests.length,
+		modules = [ ...module.childModules ];
+
+	// Do a breadth-first traversal of the child modules
+	while ( modules.length ) {
+		let nextModule =  modules.shift();
+		count += nextModule.tests.length;
+		modules.push( ...nextModule.childModules );
 	}
+
 	return count;
 }
 

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -68,6 +68,23 @@ QUnit.done( function() {
 			"testDone2",
 			"moduleDone1",
 			"moduleDone2",
+			"moduleStart1",
+			"moduleStart2",
+			"testStart1",
+			"testStart2",
+			"module3 > before",
+			"module1 > beforeEach",
+			"module3 > beforeEach",
+			"module3 > test1",
+			"log1",
+			"log2",
+			"module3 > afterEach",
+			"module1 > afterEach",
+			"module3 > after",
+			"testDone1",
+			"testDone2",
+			"moduleDone1",
+			"moduleDone2",
 			"testStart1",
 			"testStart2",
 			"module1 > beforeEach",
@@ -105,6 +122,18 @@ QUnit.module( "module1", {
 	}, function() {
 		QUnit.test( "test1", function( assert ) {
 			invokedHooks.push( "module2 > test1" );
+			assert.ok( true );
+		} );
+	} );
+
+	QUnit.module( "module3", {
+		before: callback( "module3 > before" ),
+		beforeEach: callback( "module3 > beforeEach" ),
+		afterEach: callback( "module3 > afterEach" ),
+		after: callback( "module3 > after" )
+	}, function() {
+		QUnit.test( "test1", function( assert ) {
+			invokedHooks.push( "module3 > test1" );
 			assert.ok( true );
 		} );
 	} );


### PR DESCRIPTION
As discussed in #1047:

> Modules currently have a childModule property, this contains a reference to a single module. This likely means that modules with multiple nested children are broken. We should fix that.