### PR TITLE
Build: Consume eslint-plugin-qunit, use "two" configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "browserstack-runner": "0.4.3",
     "commitplease": "2.3.0",
     "eslint-config-jquery": "1.0.0",
+    "eslint-plugin-qunit": "2.2.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "2.2.1",

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,7 +1,11 @@
 {
+	"extends": [ "plugin:qunit/two" ],
 	"env": {
 		"browser": true
 	},
+	"plugins": [
+		"qunit"
+	],
 	"globals": {
 		"QUnit": false,
 		"console": false

--- a/test/deprecated.js
+++ b/test/deprecated.js
@@ -1,4 +1,5 @@
 /*globals global: false */
+/* eslint qunit/no-setup-teardown:off, qunit/no-reset:off, qunit/no-throws-string:off, qunit/no-async-test:off, qunit/no-qunit-stop:off, qunit/no-init:off */
 
 var originalWarn = console.warn,
 	warnings = [],

--- a/test/stack-errors.js
+++ b/test/stack-errors.js
@@ -1,5 +1,6 @@
 /* global polluteGlobal:true */
 /* exported polluteGlobal */
+/* eslint qunit/no-reassign-log-callbacks:off */
 
 // No pollution
 QUnit.test( "globals", function( assert ) {


### PR DESCRIPTION
As some folks know, I maintain the [eslint-plugin-qunit](https://github.com/platinumazure/eslint-plugin-qunit) ESLint plugin. The purpose of that plugin is to provide QUnit-specific rules for ESLint.

I haven't had a good open-source project to dogfood the plugin, so now that we're using ESLint, I'd like to offer it to this project.

This PR enables all of the rules in the ["two" configuration](https://github.com/platinumazure/eslint-plugin-qunit#two) (i.e., rules related to proper use of QUnit 2.0 APIs). If there is interest and we want to use more rules from the project, that could be done in a separate PR.